### PR TITLE
Harden scope permissions and polish task UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -939,7 +939,8 @@ def update_item_rank(item_type):
         if item_class is None:
             raise ValueError(f"Model class for '{item_type}' not found.")
     except ValueError as e:
-        return str(e), 404
+        logging.exception("Model class lookup failed for item_type '%s': %s", item_type, str(e))
+        return "Item type not found.", 404
 
     for data in items_list:
         item = item_class.query.get_or_404(data["id"])

--- a/app.py
+++ b/app.py
@@ -276,23 +276,42 @@ def change_theme(theme):
 @app.before_request
 def load_scope():
     scope_selected = session.get("selected_scope")
-    if scope_selected:
-        g.scope = Scope.query.get(scope_selected)
-    else:
-        g.scope = None
+    if scope_selected and g.user:
+        scope = Scope.query.get(scope_selected)
+        if scope and _user_can_access_scope(scope):
+            g.scope = scope
+            return
+        session.pop("selected_scope", None)
+    g.scope = None
 
 def scope_required(f):
     @wraps(f)
     def decorated_function(*args, **kwargs):
-        if not g.scope:
-            flash("Please select a scope", "warning")
+        if not g.scope or not _user_can_access_scope(g.scope):
+            flash("Please select a valid scope", "warning")
             return redirect(request.referrer or url_for("home"))
         return f(*args, **kwargs)
     return decorated_function
 
 
+def _user_can_access_scope(scope: Scope) -> bool:
+    if g.user is None or scope is None:
+        return False
+    if scope.owner_id == g.user.id:
+        return True
+    return any(shared_scope.id == scope.id for shared_scope in g.user.scopes)
+
+
+def _user_owns_scope(scope: Scope) -> bool:
+    return g.user is not None and scope is not None and scope.owner_id == g.user.id
+
+
 @app.route("/scope/<int:id>")
 def set_scope(id):
+    scope = Scope.query.get_or_404(id)
+    if not _user_can_access_scope(scope):
+        flash("You do not have access to that scope.", "danger")
+        return redirect(url_for("scope"))
     session["selected_scope"] = id
     return redirect(url_for("task"))
 
@@ -321,6 +340,8 @@ def task():
 
     filtered_tasks = []
     for task in g.scope.tasks:
+        if task.owner_id != g.user.id:
+            continue
         if not show_completed and task.completed:
             continue
 
@@ -333,13 +354,20 @@ def task():
 
     available_tags = (
         Tag.query.join(Tag.tasks)
-        .filter(Task.scope_id == g.scope.id)
+        .filter(Task.scope_id == g.scope.id, Task.owner_id == g.user.id)
         .distinct()
         .order_by(Tag.name.asc())
         .all()
     )
 
-    tag_usage = {tag.id: len(tag.tasks) for tag in available_tags}
+    tag_usage = {
+        tag.id: sum(
+            1
+            for tag_task in tag.tasks
+            if tag_task.scope_id == g.scope.id and tag_task.owner_id == g.user.id
+        )
+        for tag in available_tags
+    }
 
     task_groups = []
     sortable_group_ids = []
@@ -375,11 +403,6 @@ def task():
             return item.end_date or datetime.max
 
         buckets = {
-            "without_due": {
-                "title": "Without due date",
-                "dom_id": "tasks-without-due-date",
-                "tasks": [],
-            },
             "today": {
                 "title": "Today",
                 "dom_id": "tasks-due-today",
@@ -405,6 +428,11 @@ def task():
                 "dom_id": "tasks-due-future",
                 "tasks": [],
             },
+            "without_due": {
+                "title": "Without due date",
+                "dom_id": "tasks-without-due-date",
+                "tasks": [],
+            },
         }
 
         for task in filtered_tasks:
@@ -425,7 +453,17 @@ def task():
             else:
                 buckets["future"]["tasks"].append(task)
 
-        for bucket in buckets.values():
+        bucket_order = [
+            "today",
+            "tomorrow",
+            "next_week",
+            "next_month",
+            "future",
+            "without_due",
+        ]
+
+        for bucket_key in bucket_order:
+            bucket = buckets[bucket_key]
             if not bucket["tasks"]:
                 continue
             task_groups.append(
@@ -529,16 +567,28 @@ def task():
 def list_tags():
     tags = (
         Tag.query.join(Tag.tasks)
-        .filter(Task.scope_id == g.scope.id)
+        .filter(Task.scope_id == g.scope.id, Task.owner_id == g.user.id)
         .distinct()
         .order_by(Tag.name.asc())
         .all()
     )
-    return jsonify({"tags": [tag.to_dict() for tag in tags]})
+    serialized_tags = []
+    for tag in tags:
+        payload = tag.to_dict()
+        payload["task_count"] = sum(
+            1
+            for tag_task in tag.tasks
+            if tag_task.scope_id == g.scope.id and tag_task.owner_id == g.user.id
+        )
+        serialized_tags.append(payload)
+    return jsonify({"tags": serialized_tags})
 
 
 @app.route("/tags", methods=["POST"])
+@scope_required
 def create_tag():
+    if not _user_can_access_scope(g.scope):
+        return jsonify({"error": "You do not have permission to modify tags."}), 403
     payload = request.get_json(silent=True) or {}
     raw_name = payload.get("name", "")
     normalized_name = raw_name.lstrip("#").strip().lower()
@@ -561,12 +611,27 @@ def create_tag():
         db.session.rollback()
         return jsonify({"error": str(e)}), 500
 
-    return jsonify({"tag": tag.to_dict(), "created": created})
+    tag_payload = {
+        "id": tag.id,
+        "name": tag.name,
+        "task_count": sum(
+            1
+            for tag_task in tag.tasks
+            if tag_task.scope_id == g.scope.id and tag_task.owner_id == g.user.id
+        ),
+    }
+
+    return jsonify({"tag": tag_payload, "created": created})
 
 
 @app.route("/tags/<int:tag_id>", methods=["DELETE"])
+@scope_required
 def delete_tag(tag_id):
     tag = Tag.query.get_or_404(tag_id)
+
+    for task in tag.tasks:
+        if task.owner_id != g.user.id or task.scope_id != g.scope.id:
+            return jsonify({"error": "You do not have permission to delete this tag."}), 403
 
     try:
         for task in list(tag.tasks):
@@ -583,7 +648,12 @@ def delete_tag(tag_id):
 
 def _get_task_in_scope_or_404(task_id):
     task = Task.query.get_or_404(task_id)
-    if g.scope is None or task.scope_id != g.scope.id:
+    if (
+        g.scope is None
+        or task.scope_id != g.scope.id
+        or task.owner_id != g.user.id
+        or not _user_can_access_scope(task.scope)
+    ):
         abort(404)
     return task
 
@@ -701,7 +771,7 @@ def add_task():
     item = Task()
     form = TaskForm()
     form.tags.data = form.tags.data or ""
-    items = [item for item in g.scope.tasks if not item.completed]
+    items = [item for item in g.scope.tasks if item.owner_id == g.user.id and not item.completed]
     show_modal = False
     print(form.errors)
     if form.validate_on_submit():
@@ -742,6 +812,8 @@ def add_task():
 def edit_scope(id):
     items = g.user.owned_scopes + g.user.scopes
     item = Scope.query.get_or_404(id)
+    if not _user_owns_scope(item):
+        abort(404)
     form = ScopeForm(obj=item)
     show_modal = False
 
@@ -764,8 +836,10 @@ def edit_scope(id):
 @app.route("/task/edit/<int:id>", methods=["GET", "POST"])
 @scope_required
 def edit_task(id):
-    items = [task for task in g.scope.tasks if not task.completed]
+    items = [task for task in g.scope.tasks if task.owner_id == g.user.id and not task.completed]
     item = Task.query.get_or_404(id)
+    if item.scope_id != g.scope.id or item.owner_id != g.user.id:
+        abort(404)
     form = TaskForm(obj=item)
     form.tags.data = ",".join(str(tag.id) for tag in item.tags)
     show_modal = False
@@ -801,7 +875,34 @@ def delete_item(item_type, id):
             # TODO: This may need to be adjusted for CamelCase
             item_class = globals().get(item_type.capitalize())
             item = item_class.query.get_or_404(id)
-                
+
+            if item_type == "scope":
+                if not _user_owns_scope(item):
+                    return (
+                        jsonify(
+                            {
+                                "success": False,
+                                "message": "You do not have permission to delete this scope.",
+                            }
+                        ),
+                        403,
+                    )
+            elif item_type == "task":
+                if (
+                    item.scope is None
+                    or not _user_can_access_scope(item.scope)
+                    or item.owner_id != g.user.id
+                ):
+                    return (
+                        jsonify(
+                            {
+                                "success": False,
+                                "message": "You do not have permission to delete this task.",
+                            }
+                        ),
+                        403,
+                    )
+
             db.session.delete(item)
             db.session.commit()
             flash(f"{item_class.__name__} deleted!", "success")
@@ -818,7 +919,7 @@ def delete_item(item_type, id):
 @scope_required
 def complete_task(id):
     try:
-        item = Task.query.get_or_404(id)
+        item = _get_task_in_scope_or_404(id)
         if item.completed:
             item.uncomplete_task()
         else:
@@ -833,14 +934,28 @@ def complete_task(id):
 @app.route("/<string:item_type>/rank", methods=["POST"])
 def update_item_rank(item_type):
     items_list = request.json["items"]
+    try:
+        item_class = globals().get(item_type.capitalize())
+        if item_class is None:
+            raise ValueError(f"Model class for '{item_type}' not found.")
+    except ValueError as e:
+        return str(e), 404
+
     for data in items_list:
-        try:
-            item_class = globals().get(item_type.capitalize())
-            item = item_class.query.get_or_404(data["id"])
-            item.rank = data["newRank"]
-            db.session.commit()
-        except ValueError as e:
-            return str(e), 404
+        item = item_class.query.get_or_404(data["id"])
+
+        if item_type == "task":
+            if g.scope is None or not _user_can_access_scope(g.scope):
+                return jsonify({"error": "No scope selected."}), 400
+            if item.scope_id != g.scope.id or item.owner_id != g.user.id:
+                return jsonify({"error": "You do not have permission to reorder this task."}), 403
+        elif item_type == "scope":
+            if not _user_owns_scope(item):
+                return jsonify({"error": "You do not have permission to reorder this scope."}), 403
+
+        item.rank = data["newRank"]
+
+    db.session.commit()
     return jsonify({"success": True})
 
 

--- a/templates/components/task_groups.html
+++ b/templates/components/task_groups.html
@@ -38,17 +38,17 @@
                                     {% endif %}
                                 </div>
                                 <div class="col-auto d-flex justify-content-end align-items-center">
-                                    <a class="btn btn-pastel-success mx-1" href="{{ url_for('complete_task', id=task.id) }}">
+                                    <a class="btn task-action-btn mx-1" href="{{ url_for('complete_task', id=task.id) }}">
                                         {% if task.completed %}
                                             <i class="bi bi-arrow-counterclockwise"></i>
                                         {% else %}
                                             <i class="bi bi-check"></i>
                                         {% endif %}
                                     </a>
-                                    <button type="button" class="btn btn-outline-secondary tag-manager-btn" data-task-id="{{ task.id }}" data-task-name="{{ task.name | e }}">
+                                    <button type="button" class="btn task-action-btn mx-1 tag-manager-btn" data-task-id="{{ task.id }}" data-task-name="{{ task.name | e }}">
                                         <i class="bi bi-tags"></i>
                                     </button>
-                                    <button type="button" class="btn btn-outline-secondary mx-1 edit-task-btn"
+                                    <button type="button" class="btn task-action-btn mx-1 edit-task-btn"
                                         data-task-id="{{ task.id }}"
                                         data-task-name="{{ task.name | e }}"
                                         data-task-description="{{ task.description | default('') | e }}"
@@ -57,7 +57,7 @@
                                     >
                                         <i class="bi bi-pencil"></i>
                                     </button>
-                                    <button type="button" class="btn btn-pastel-danger" onclick="showConfirmationModal('{{ url_for('delete_item', item_type='task', id=task.id) }}','Confirm Action','Are you sure?')">
+                                    <button type="button" class="btn task-action-btn mx-1" onclick="showConfirmationModal('{{ url_for('delete_item', item_type='task', id=task.id) }}','Confirm Action','Are you sure?')">
                                         <i class="bi bi-trash"></i>
                                     </button>
                                 </div>

--- a/templates/scope.html
+++ b/templates/scope.html
@@ -17,8 +17,9 @@
     {% for scope in scopes %}
         <div class="col">
             <div class="card border-secondary" >
-                <div class="card-header d-flex justify-content-between align-items-top" id="grip" data-item-id="{{ scope.id }}"> 
-                    <i class="bi bi-grip-vertical text-muted"></i>
+                <div class="card-header d-flex justify-content-between align-items-top" {% if scope.owner_id == g.user.id %}id="grip" data-item-id="{{ scope.id }}"{% endif %}>
+                    <i class="bi bi-grip-vertical text-muted {% if scope.owner_id != g.user.id %}opacity-50{% endif %}"></i>
+                    {% if scope.owner_id == g.user.id %}
                     <div class="d-flex justify-content-between">
                         <i class="bi bi-pencil edit-scope-btn clickable-icon text-muted mx-1"
                             data-bs-toggle="modal"
@@ -26,9 +27,12 @@
                             data-scope-id="{{ scope.id }}"
                             data-scope-name="{{ scope.name }}"
                             data-scope-description="{{ scope.description }}"></i>
-                        <i class="bi bi-trash3 clickable-icon text-muted small mx-1" 
+                        <i class="bi bi-trash3 clickable-icon text-muted small mx-1"
                             onclick="showConfirmationModal('{{url_for('delete_item',item_type='scope', id=scope.id)}}','Confirm Action','Are you sure?')"></i>
                     </div>
+                    {% else %}
+                    <div class="d-flex"></div>
+                    {% endif %}
                 </div>
                 <a class="text-decoration-none no-visited" href="{{url_for('set_scope',id=scope.id)}}">
                     <div class="card-body text-center">{{scope.name}}</div>

--- a/templates/task.html
+++ b/templates/task.html
@@ -9,11 +9,13 @@
     .tag-pill {
         border-radius: 999px;
         padding: 0.25rem 0.75rem;
-        font-size: 0.85rem;
+        font-size: var(--bs-body-font-size, 1rem);
+        font-weight: 500;
         display: inline-flex;
         align-items: center;
         gap: 0.25rem;
-        border: 1px solid var(--bs-border-color);
+        border: var(--bs-border-width, 1px) solid var(--bs-border-color);
+        border-width: calc(var(--bs-border-width, 1px) * 1.5);
         transition: all 0.15s ease-in-out;
     }
 
@@ -41,7 +43,6 @@
 
     .tag-pill {
         background-color: var(--bs-tertiary-bg);
-        border-color: transparent;
         color: var(--bs-secondary-color, var(--bs-secondary));
     }
 
@@ -126,7 +127,10 @@
     .inline-tag-chip {
         border-radius: 999px;
         padding: 0.25rem 0.75rem;
-        border: 1px solid var(--bs-border-color);
+        border: var(--bs-border-width, 1px) solid var(--bs-border-color);
+        border-width: calc(var(--bs-border-width, 1px) * 1.5);
+        font-size: var(--bs-body-font-size, 1rem);
+        font-weight: 500;
         background-color: var(--bs-body-bg);
         cursor: pointer;
         display: inline-flex;
@@ -169,6 +173,20 @@
 
     .tag-filter-button .tag-filter-remove i {
         pointer-events: none;
+    }
+
+    .task-action-btn {
+        border: var(--bs-border-width, 1px) solid var(--bs-border-color);
+        background-color: var(--bs-tertiary-bg);
+        color: var(--bs-body-color);
+        transition: all 0.15s ease-in-out;
+    }
+
+    .task-action-btn:hover,
+    .task-action-btn:focus {
+        background-color: var(--bs-secondary-bg, #e9ecef);
+        border-color: var(--bs-secondary-border-subtle, #ced4da);
+        color: var(--bs-body-color);
     }
 </style>
 {% endblock %}
@@ -268,7 +286,7 @@
                 <div class="mb-3">
                     <div class="d-flex flex-wrap gap-2" id="task-inline-tag-options"></div>
                     <p class="text-muted small mb-2 d-none" id="task-inline-tag-empty">No tags yet. Create one below.</p>
-                    <div class="input-group input-group-sm inline-tag-input-group">
+                    <div class="input-group input-group-sm inline-tag-input-group mt-3">
                         <span class="input-group-text">#</span>
                         <input type="text" class="form-control" id="task-inline-tag-input" placeholder="Add a tag and press Enter">
                         <button class="btn btn-outline-primary" type="button" id="task-inline-tag-add">Add</button>
@@ -404,18 +422,13 @@
     const quickToggleIcon = document.querySelector('[data-bs-target="#detailed-item-container"] i');
 
     if (detailedItemContainer && quickToggleIcon) {
-        const updateQuickToggleIcon = () => {
-            if (detailedItemContainer.classList.contains('show')) {
-                quickToggleIcon.classList.remove('bi-chevron-down');
-                quickToggleIcon.classList.add('bi-chevron-up');
-            } else {
-                quickToggleIcon.classList.remove('bi-chevron-up');
-                quickToggleIcon.classList.add('bi-chevron-down');
-            }
+        const setQuickToggleIcon = (isExpanded) => {
+            quickToggleIcon.classList.toggle('bi-chevron-down', !isExpanded);
+            quickToggleIcon.classList.toggle('bi-chevron-up', isExpanded);
         };
-        updateQuickToggleIcon();
-        detailedItemContainer.addEventListener('show.bs.collapse', updateQuickToggleIcon);
-        detailedItemContainer.addEventListener('hide.bs.collapse', updateQuickToggleIcon);
+        setQuickToggleIcon(detailedItemContainer.classList.contains('show'));
+        detailedItemContainer.addEventListener('show.bs.collapse', () => setQuickToggleIcon(true));
+        detailedItemContainer.addEventListener('hide.bs.collapse', () => setQuickToggleIcon(false));
     }
 
     function convertToLocal(utcDateString) {
@@ -920,10 +933,22 @@
             ? Array.from(filterContainer.querySelectorAll('.tag-filter-button.active')).map((button) => button.dataset.tagId)
             : [];
 
+        const groupsContainer = getTaskGroupsContainer();
+        const currentSort = groupsContainer ? groupsContainer.dataset.sortBy : null;
+
         document.querySelectorAll('.task-item').forEach((taskElement) => {
             const taskTags = (taskElement.dataset.tagIds || '').split(',').filter(Boolean);
             const matches = activeTags.every((tagId) => taskTags.includes(tagId));
             taskElement.style.display = matches ? '' : 'none';
+        });
+
+        document.querySelectorAll('.task-group').forEach((group) => {
+            if (currentSort === 'tags') {
+                const hasVisibleTask = Array.from(group.querySelectorAll('.task-item')).some((task) => task.style.display !== 'none');
+                group.style.display = hasVisibleTask ? '' : 'none';
+            } else {
+                group.style.display = '';
+            }
         });
     }
 
@@ -1273,7 +1298,7 @@
     if (searchInput) {
         const debouncedSearch = debounce(() => {
             refreshTaskList();
-        }, 250);
+        }, 300);
         searchInput.addEventListener('input', () => {
             debouncedSearch();
         });


### PR DESCRIPTION
## Summary
- gate scope selection, ranking, and deletion routes with ownership checks and updated helpers
- restrict task listings, tag APIs, and due-date grouping to the signed-in user and current scope
- refresh the task UI with consistent action buttons, improved chevrons, tag styling, and slower search debounce

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_b_68dcd5ffa6948330b3e80bb61c16d165