### PR TITLE
Unify modals and enhance task interactions

### DIFF
--- a/app.py
+++ b/app.py
@@ -898,10 +898,11 @@ def edit_task(id):
             form = TaskForm()
         except SQLAlchemyError as e:
             db.session.rollback()
-            error_message = f"An error occurred: {str(e)}"
+            logging.error("Database error during task update", exc_info=True)
+            generic_error_message = "An internal error occurred while updating the task. Please try again later."
             if wants_json:
-                return jsonify({"success": False, "message": error_message}), 500
-            flash(error_message, "error")
+                return jsonify({"success": False, "message": generic_error_message}), 500
+            flash(generic_error_message, "error")
         return redirect(request.referrer or url_for("task"))
     else:
         if wants_json:

--- a/app.py
+++ b/app.py
@@ -821,7 +821,8 @@ def add_task():
             form = TaskForm()
         except SQLAlchemyError as e:
             db.session.rollback()
-            error_message = f"An error occurred: {str(e)}"
+            logging.error("Database error while adding task", exc_info=True)
+            error_message = "An internal error has occurred."
             if wants_json:
                 return jsonify({"success": False, "message": error_message}), 500
             flash(error_message, "error")

--- a/docs/ai-output-history.md
+++ b/docs/ai-output-history.md
@@ -74,3 +74,5 @@ The application has a solid foundation but requires attention to security and bu
 --------------------------------------------------------
 --------------------------------------------------------
 --------------------------------------------------------
+--------------------------------------------------------
+2025-10-01 – UI polish: unified modal styling, confirmation modals, task AJAX + filter retention, and copy updates.

--- a/templates/app.html
+++ b/templates/app.html
@@ -23,14 +23,60 @@
     overflow: hidden; /* Prevent content from spilling during height transition */
 }
 
+.modal-content {
+    border-radius: 1rem;
+    border: 1px solid var(--bs-border-color);
+    background-color: var(--bs-body-bg);
+    box-shadow: 0 0.75rem 2rem rgba(33, 37, 41, 0.2);
+}
+
+.modal-header {
+    border-bottom: 1px solid var(--bs-border-color);
+}
+
+.modal-footer {
+    border-top: 1px solid var(--bs-border-color);
+}
+
+.modal-title {
+    font-weight: 600;
+}
+
 </style>
-{% endblock css %} 
+{% endblock css %}
 
 
 {% block scripts %}
     {{ super() }}
 
 <script>
+    window.displayFlashMessage = function(message, type = 'info') {
+        const flashContainer = document.getElementById('flash-container');
+        const target = flashContainer || document.body;
+        const alert = document.createElement('div');
+        alert.className = `alert alert-${type} alert-dismissible fade show mt-2`;
+        alert.setAttribute('role', 'alert');
+        alert.innerHTML = `
+            <div class="d-flex align-items-center gap-2">
+                <span>${message}</span>
+                <button type="button" class="btn-close ms-auto" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+        `;
+
+        if (target.firstChild) {
+            target.insertBefore(alert, target.firstChild);
+        } else {
+            target.appendChild(alert);
+        }
+
+        if (type === 'success' || type === 'info') {
+            window.setTimeout(() => {
+                const instance = bootstrap.Alert.getOrCreateInstance(alert);
+                instance.close();
+            }, 5000);
+        }
+    };
+
     function expandAccordionItem(accordionItemId) {
         var toggleElement = document.querySelector(`[data-bs-target="#${accordionItemId}"]`);
         if (toggleElement && toggleElement.classList.contains('collapsed')) {

--- a/templates/components/flash.html
+++ b/templates/components/flash.html
@@ -1,21 +1,23 @@
-{% with messages = get_flashed_messages(with_categories=true) %}
-    {% if messages %}
-        {% for category, message in messages %}
-            {% if category %}
-            <div class="alert alert-dismissible alert-{{ category }}" {% if category=='info' or category=='success' %}
-                data-auto-dismiss{% endif %}>
-                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-                {{ message }}
-            </div>
-            {% else %}
-            <div class="alert alert-dismissible alert-secondary">
-                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-                {{ message }}
-            </div>
-            {% endif %}
-        {% endfor %}
-    {% endif %}
-{% endwith %}
+<div id="flash-container" class="mt-3">
+    {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+            {% for category, message in messages %}
+                {% if category %}
+                <div class="alert alert-dismissible alert-{{ category }}" {% if category=='info' or category=='success' %}
+                    data-auto-dismiss{% endif %}>
+                    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+                    {{ message }}
+                </div>
+                {% else %}
+                <div class="alert alert-dismissible alert-secondary">
+                    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+                    {{ message }}
+                </div>
+                {% endif %}
+            {% endfor %}
+        {% endif %}
+    {% endwith %}
+</div>
 
 <script>
     window.addEventListener('load', () => {

--- a/templates/components/task_groups.html
+++ b/templates/components/task_groups.html
@@ -8,13 +8,13 @@
             {% if group.title %}
                 {% set show_quick_add = (sort_by == 'tags' and group.tag_id is defined) or (sort_by == 'due_date' and group.due_bucket is defined) %}
                 <div class="task-group-header">
-                    <h6 class="text-uppercase text-muted small mb-2 flex-grow-1">{{ group.title }}</h6>
+                    <h6 class="task-group-title text-uppercase text-muted small mb-0">{{ group.title }}</h6>
                     {% if show_quick_add %}
                         <button type="button"
                                 class="btn btn-outline-primary btn-sm task-group-add-btn"
                                 {% if group.tag_id is defined %}data-group-tag-id="{{ group.tag_id if group.tag_id is not none else '' }}"{% endif %}
                                 {% if group.due_bucket is defined %}data-group-due-bucket="{{ group.due_bucket }}"{% endif %}
-                                aria-label="Add task for {{ group.title }}">
+                                aria-label="Quick add task for {{ group.title }}">
                             <i class="bi bi-plus-lg"></i>
                         </button>
                     {% endif %}
@@ -29,7 +29,7 @@
                                 <div class="d-flex align-items-center flex-grow-1">
                                     <i class="bi bi-grip-vertical text-muted {{ '' if group.sortable else 'drag-disabled' }}" id="grip" data-item-id="{{ task.id }}"></i>
                                     {% if has_details %}
-                                        <a href="#" class="text-decoration-none text-body task-toggle no-visited d-flex align-items-center flex-grow-1 gap-2 ms-2 collapsed" data-bs-toggle="collapse" data-bs-target="#collapse{{ group.dom_id }}-{{ task.id }}" aria-expanded="false" aria-controls="collapse{{ group.dom_id }}-{{ task.id }}">
+                                        <a href="#" class="text-decoration-none task-toggle no-visited d-flex align-items-center flex-grow-1 gap-2 ms-2 collapsed" data-bs-toggle="collapse" data-bs-target="#collapse{{ group.dom_id }}-{{ task.id }}" aria-expanded="false" aria-controls="collapse{{ group.dom_id }}-{{ task.id }}">
                                             <div class="flex-grow-1 task-title">
                                                 {% if task.completed %}
                                                     <del>{{ task.name }}</del>
@@ -40,7 +40,7 @@
                                             <i class="bi bi-chevron-right task-chevron" data-chevron-for="collapse{{ group.dom_id }}-{{ task.id }}" aria-hidden="true"></i>
                                         </a>
                                     {% else %}
-                                        <div class="mx-2 flex-grow-1 task-title text-body">
+                                        <div class="mx-2 flex-grow-1 task-title">
                                             {% if task.completed %}
                                                 <del>{{ task.name }}</del>
                                             {% else %}
@@ -69,7 +69,10 @@
                                     >
                                         <i class="bi bi-pencil"></i>
                                     </button>
-                                    <button type="button" class="btn task-action-btn" onclick="showConfirmationModal('{{ url_for('delete_item', item_type='task', id=task.id) }}','Confirm Action','Are you sure?')">
+                                    <button type="button" class="btn task-action-btn task-delete-btn"
+                                        data-confirm-url="{{ url_for('delete_item', item_type='task', id=task.id) }}"
+                                        data-task-name="{{ task.name | e }}"
+                                        aria-label="Delete task {{ task.name }}">
                                         <i class="bi bi-trash"></i>
                                     </button>
                                 </div>

--- a/templates/modals/confirmation_modal.html
+++ b/templates/modals/confirmation_modal.html
@@ -1,64 +1,80 @@
-<div class="modal fade" id="confirmationModal" tabindex="-1" aria-labelledby="confirmationModalTitle"
-  aria-hidden="true">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title" id="confirmationModalTitle">Title TBD</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-      </div>
-      <div class="modal-body" id="confirmationModalBody">Message TBD</div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
-          Cancel
-        </button>
-        <button type="button" class="btn btn-danger" id="confirmButton">
-          Confirm
-        </button>
-      </div>
+<div class="modal fade" id="confirmationModal" tabindex="-1" aria-labelledby="confirmationModalTitle" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-sm">
+        <div class="modal-content">
+            <div class="modal-header border-0 pb-0">
+                <h5 class="modal-title" id="confirmationModalTitle">Confirm action</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <p class="mb-0" id="confirmationModalBody">Are you sure you want to continue?</p>
+            </div>
+            <div class="modal-footer border-0 pt-0">
+                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-danger" id="confirmButton">Confirm</button>
+            </div>
+        </div>
     </div>
-  </div>
 </div>
 
 <script>
-  // Display the ACTION confitmation modal
-  function showConfirmationModal(action_url, title, message) {
-    // Update the modal tittle and message
-    document.getElementById("confirmationModalTitle").textContent = title;
-    document.getElementById("confirmationModalBody").textContent = message;
+(() => {
+    const modalElement = document.getElementById('confirmationModal');
+    if (!modalElement) {
+        return;
+    }
 
-    const confirmButton = document.getElementById("confirmButton");
+    const modalTitle = document.getElementById('confirmationModalTitle');
+    const modalBody = document.getElementById('confirmationModalBody');
+    const confirmButton = document.getElementById('confirmButton');
+    const modalInstance = new bootstrap.Modal(modalElement);
 
-    confirmButton.onclick = function () {
-      fetch(action_url, { method: "POST" })
-        .then((response) => response.json())
-        .then((data) => {
-          if (data.success) {
-            displayFlashMessage(data.message, 'success');
-            window.location.reload(); // or update the page content as needed
-          } else {
-            displayFlashMessage(data.message, 'danger');
-          }
-        })
-        .catch((error) => {
-          console.error("Error:", error);
-          displayFlashMessage('An unexpected error occurred', 'danger');
+    let resolver = null;
+    let wasConfirmed = false;
+    const defaultConfirmClass = 'btn btn-danger';
+
+    confirmButton.addEventListener('click', () => {
+        wasConfirmed = true;
+        modalInstance.hide();
+    });
+
+    modalElement.addEventListener('hidden.bs.modal', () => {
+        if (typeof resolver === 'function') {
+            resolver(wasConfirmed);
+        }
+        wasConfirmed = false;
+        resolver = null;
+        confirmButton.className = defaultConfirmClass;
+        confirmButton.textContent = 'Confirm';
+    });
+
+    window.showConfirmationModal = function showConfirmationModal({
+        title = 'Confirm action',
+        message = 'Are you sure you want to continue?',
+        confirmLabel = 'Confirm',
+        confirmVariant = 'danger',
+    } = {}) {
+        if (modalTitle) {
+            modalTitle.textContent = title;
+        }
+        if (modalBody) {
+            modalBody.textContent = message;
+        }
+        if (confirmButton) {
+            const normalizedVariant = (confirmVariant || 'danger').trim();
+            if (normalizedVariant.startsWith('btn')) {
+                confirmButton.className = normalizedVariant;
+            } else if (normalizedVariant.includes(' ')) {
+                confirmButton.className = `btn ${normalizedVariant}`;
+            } else {
+                confirmButton.className = `btn btn-${normalizedVariant}`;
+            }
+            confirmButton.textContent = confirmLabel;
+        }
+
+        modalInstance.show();
+        return new Promise((resolve) => {
+            resolver = resolve;
         });
     };
-
-    // Show the modal
-    var confirmationModal = new bootstrap.Modal(
-      document.getElementById("confirmationModal")
-    );
-    confirmationModal.show();
-  }
-
-  function displayFlashMessage(message, type) {
-    const alertDiv = document.createElement('div');
-    alertDiv.className = `alert alert-${type} alert-dismissible fade show`;
-    alertDiv.role = 'alert';
-    alertDiv.innerHTML = `${message} <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>`;
-
-    document.body.prepend(alertDiv); // Adjust where the alert should be added in the DOM
-    setTimeout(() => alertDiv.style.display = 'none', 5000); // Auto-dismiss after 5 seconds
-  }
+})();
 </script>

--- a/templates/modals/login_modal.html
+++ b/templates/modals/login_modal.html
@@ -1,11 +1,12 @@
 <div class="modal fade" id="loginModal" tabindex="-1" aria-hidden="true">
-    <div class="modal-dialog">
+    <div class="modal-dialog modal-dialog-centered modal-sm">
         <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title">Login</h5>
+            <div class="modal-header border-0 pb-0">
+                <h5 class="modal-title">Sign in</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <div class="modal-body">
+            <div class="modal-body pt-2">
+                <p class="text-muted small mb-3">Enter your credentials to access Projects Manager.</p>
                 {% include 'forms/login_form.html' %}
             </div>
         </div>

--- a/templates/modals/scope_modal.html
+++ b/templates/modals/scope_modal.html
@@ -1,16 +1,17 @@
-<div class="modal fade" id="scope-modal" tabindex="-1">
-    <div class="modal-dialog">
+<div class="modal fade" id="scope-modal" tabindex="-1" aria-labelledby="scope-modal-title" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
-            
-            <div class="modal-header">
-                <h5 class="modal-title" id="scope-modal-title">{{ action }} Scope</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+
+            <div class="modal-header border-0 pb-0">
+                <h5 class="modal-title" id="scope-modal-title">Create scope</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            
+
             <form id="scope-form" method="post">
             {{ scope_form.hidden_tag() }}
-            
-            <div class="modal-body">
+
+            <div class="modal-body pt-2">
+                <p class="text-muted small mb-3" id="scope-modal-description">Organize tasks by creating a new scope.</p>
                 <div class="form-floating mb-3">
                     {{ scope_form.name(class_='form-control'+ (' is-invalid' if scope_form.name.errors else ''), placeholder_=scope_form.name.name) }}
                     {{ scope_form.name.label(class="form-label") }}
@@ -23,7 +24,7 @@
                 <div class="form-floating mb-3">
                     {{ scope_form.description(class_='form-control'+ (' is-invalid' if scope_form.description.errors else ''), placeholder_=scope_form.description.name) }}
                     {{ scope_form.description.label(class="form-label") }}
-                    {% if scope_form.name.errors %}
+                    {% if scope_form.description.errors %}
                         {% for error in scope_form.description.errors %}
                             <div class="invalid-feedback" style="display:block;">{{ error }}</div>
                         {% endfor %}
@@ -31,50 +32,97 @@
                 </div>
             </div>
 
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
+            <div class="modal-footer border-0 pt-0">
+                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">
                 Cancel
                 </button>
                 {{ scope_form.submit(class="btn btn-primary") }}
             </div>
-                
+
             </form>
         </div>
     </div>
 </div>
 
 <script>
-    // Display the modal based on the flag.
-    // Used when validation of the form fails to display the modal by default.
-    // Sets the modal butons depending on the action clicked (ADD or EDIT)
-    document.addEventListener('DOMContentLoaded', (event) => {
+    const scopeForm = document.getElementById('scope-form');
+    const scopeModalTitle = document.getElementById('scope-modal-title');
+    const scopeModalDescription = document.getElementById('scope-modal-description');
+    const scopeSubmitButton = scopeForm ? scopeForm.querySelector('[type="submit"]') : null;
+
+    function setScopeModalContent({ title, description, submitLabel }) {
+        if (scopeModalTitle) {
+            scopeModalTitle.textContent = title;
+        }
+        if (scopeModalDescription) {
+            scopeModalDescription.textContent = description;
+        }
+        if (scopeSubmitButton) {
+            scopeSubmitButton.value = submitLabel;
+            scopeSubmitButton.textContent = submitLabel;
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        const defaultAction = '{{ url_for("add_scope") }}';
+        if (scopeForm) {
+            const currentAction = scopeForm.getAttribute('action') || defaultAction;
+            if (currentAction !== defaultAction) {
+                setScopeModalContent({
+                    title: 'Edit scope',
+                    description: 'Update the scope details below.',
+                    submitLabel: 'Save changes',
+                });
+            } else {
+                setScopeModalContent({
+                    title: 'Create scope',
+                    description: 'Organize tasks by creating a new scope.',
+                    submitLabel: 'Create scope',
+                });
+            }
+        }
+
         {% if show_modal %}
-            var modal = new bootstrap.Modal(document.getElementById('{{show_modal}}'));
+            const modal = new bootstrap.Modal(document.getElementById('{{ show_modal }}'));
             modal.show();
         {% endif %}
     });
 
-    // Update the form action when the ADD button is clicked
-    // Clears the form fields
-    document.getElementById("add-scope-btn").addEventListener("click", (event) => {
-        actionUrl = '{{ url_for("add_scope") }}';
-        document.querySelector("#scope-form").action = actionUrl;
-        document.getElementById("scope-form").reset();
-    });
+    const addScopeBtn = document.getElementById('add-scope-btn');
+    if (addScopeBtn && scopeForm) {
+        addScopeBtn.addEventListener('click', () => {
+            scopeForm.action = '{{ url_for("add_scope") }}';
+            scopeForm.reset();
+            setScopeModalContent({
+                title: 'Create scope',
+                description: 'Organize tasks by creating a new scope.',
+                submitLabel: 'Create scope',
+            });
+        });
+    }
 
-    // Update the modal form action when the EDIT button is clicked
-    // Populate the form with the values associated to the EDIT button
-    document.querySelectorAll(".edit-scope-btn").forEach((item) => {
-        item.addEventListener("click", (event) => {
+    document.querySelectorAll('.edit-scope-btn').forEach((item) => {
+        item.addEventListener('click', () => {
             {% for field in scope_form %}
                 {% if field.name != 'csrf_token' and field.type != 'SubmitField' %}
-                    document.getElementById('{{ field.name }}').value = item.getAttribute("data-scope-{{ field.name }}");
+                    const fieldElement = document.getElementById('{{ field.name }}');
+                    if (fieldElement) {
+                        fieldElement.value = item.getAttribute('data-scope-{{ field.name }}') || '';
+                    }
                 {% endif %}
             {% endfor %}
 
-            let baseUrl = '{{ url_for("edit_scope", id=0) }}';
-            let actionUrl = baseUrl.replace("/0", "/" + item.getAttribute("data-scope-id"));
-            document.querySelector("#scope-form").action = actionUrl;
+            if (scopeForm) {
+                const baseUrl = '{{ url_for("edit_scope", id=0) }}';
+                const actionUrl = baseUrl.replace('/0', `/${item.getAttribute('data-scope-id')}`);
+                scopeForm.action = actionUrl;
+            }
+
+            setScopeModalContent({
+                title: 'Edit scope',
+                description: 'Update the scope details below.',
+                submitLabel: 'Save changes',
+            });
         });
     });
 </script>

--- a/templates/modals/task_modal.html
+++ b/templates/modals/task_modal.html
@@ -1,16 +1,17 @@
-<div class="modal fade" id="task-modal" tabindex="-1">
-    <div class="modal-dialog">
+<div class="modal fade" id="task-modal" tabindex="-1" aria-labelledby="task-modal-title" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
-            
-            <div class="modal-header">
+
+            <div class="modal-header border-0 pb-0">
                 <h5 class="modal-title" id="task-modal-title">{{ action }} Task</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            
+
             <form id="task-form" method="post">
             {{ task_form.hidden_tag() }}
-            
-            <div class="modal-body">
+
+            <div class="modal-body pt-2">
+                <p class="text-muted small mb-3" id="task-modal-description">Capture the details for this task below.</p>
                 <div class="form-floating mb-3">
                     {{ task_form.name(class_='form-control'+ (' is-invalid' if task_form.name.errors else ''), placeholder_=task_form.name.name) }}
                     {{ task_form.name.label(class="form-label") }}
@@ -40,8 +41,8 @@
                 </div>
             </div>
 
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
+            <div class="modal-footer border-0 pt-0">
+                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">
                 Cancel
                 </button>
                 <button type="submit" class="btn btn-primary" name="submitTaskButton" id="submitTaskButton">

--- a/templates/scope.html
+++ b/templates/scope.html
@@ -21,14 +21,23 @@
                     <i class="bi bi-grip-vertical text-muted {% if scope.owner_id != g.user.id %}opacity-50{% endif %}"></i>
                     {% if scope.owner_id == g.user.id %}
                     <div class="d-flex justify-content-between">
-                        <i class="bi bi-pencil edit-scope-btn clickable-icon text-muted mx-1"
+                        <button type="button"
+                            class="btn btn-link p-0 text-muted edit-scope-btn clickable-icon mx-1"
                             data-bs-toggle="modal"
                             data-bs-target="#scope-modal"
                             data-scope-id="{{ scope.id }}"
                             data-scope-name="{{ scope.name }}"
-                            data-scope-description="{{ scope.description }}"></i>
-                        <i class="bi bi-trash3 clickable-icon text-muted small mx-1"
-                            onclick="showConfirmationModal('{{url_for('delete_item',item_type='scope', id=scope.id)}}','Confirm Action','Are you sure?')"></i>
+                            data-scope-description="{{ scope.description }}"
+                            aria-label="Edit scope {{ scope.name }}">
+                            <i class="bi bi-pencil"></i>
+                        </button>
+                        <button type="button"
+                            class="btn btn-link p-0 text-muted scope-delete-btn mx-1"
+                            data-confirm-url="{{ url_for('delete_item',item_type='scope', id=scope.id) }}"
+                            data-scope-name="{{ scope.name | e }}"
+                            aria-label="Delete scope {{ scope.name }}">
+                            <i class="bi bi-trash3"></i>
+                        </button>
                     </div>
                     {% else %}
                     <div class="d-flex"></div>
@@ -54,6 +63,57 @@
     {{ super() }}
 <script>
     initializeSortable('scopes-list', 'scope');
+
+    document.querySelectorAll('.scope-delete-btn').forEach((button) => {
+        button.addEventListener('click', (event) => {
+            event.preventDefault();
+            if (typeof showConfirmationModal !== 'function') {
+                return;
+            }
+            const actionUrl = button.dataset.confirmUrl;
+            if (!actionUrl) {
+                return;
+            }
+            const scopeName = button.dataset.scopeName || 'this scope';
+            showConfirmationModal({
+                title: 'Delete scope',
+                message: `Delete scope "${scopeName}"? This action cannot be undone.`,
+                confirmLabel: 'Delete scope',
+                confirmVariant: 'danger',
+            }).then((confirmed) => {
+                if (!confirmed) {
+                    return;
+                }
+                fetch(actionUrl, {
+                    method: 'POST',
+                    headers: {
+                        'X-Requested-With': 'XMLHttpRequest',
+                        Accept: 'application/json',
+                    },
+                })
+                    .then((response) =>
+                        response
+                            .json()
+                            .catch(() => ({}))
+                            .then((data) => ({ ok: response.ok, data }))
+                    )
+                    .then(({ ok, data }) => {
+                        if (!ok || !data || data.success !== true) {
+                            const message = (data && data.message) || `Unable to delete "${scopeName}".`;
+                            displayFlashMessage(message, 'danger');
+                            return;
+                        }
+                        const message = (data && data.message) || `Scope "${scopeName}" deleted.`;
+                        displayFlashMessage(message, 'success');
+                        window.location.reload();
+                    })
+                    .catch((error) => {
+                        console.error('Unable to delete scope', error);
+                        displayFlashMessage(`Unable to delete "${scopeName}".`, 'danger');
+                    });
+            });
+        });
+    });
 </script>
 
 

--- a/templates/task.html
+++ b/templates/task.html
@@ -372,7 +372,7 @@
                     <div class="invalid-feedback {% if not description_error %}d-none{% endif %}" data-feedback-for="description">{{ description_error }}</div>
                 </div>
                 <div class="form-floating mb-3">
-                    {{ task_form.end_date(class_='form-control'+ (' is-invalid' if task_form.end_date.errors else ''), placeholder_='Add more details') }}
+                    {{ task_form.end_date(class_='form-control'+ (' is-invalid' if task_form.end_date.errors else ''), placeholder_='YYYY-MM-DD') }}
                     {{ task_form.end_date.label(class_='form-label') }}
                     {% set end_date_error = task_form.end_date.errors[0] if task_form.end_date.errors else '' %}
                     <div class="invalid-feedback {% if not end_date_error %}d-none{% endif %}" data-feedback-for="end_date">{{ end_date_error }}</div>

--- a/templates/task.html
+++ b/templates/task.html
@@ -51,9 +51,10 @@
         align-items: center;
         gap: 0.5rem;
         margin-bottom: 0.5rem;
+        flex-wrap: wrap;
     }
 
-    .task-group-header h6 {
+    .task-group-title {
         margin-bottom: 0;
     }
 
@@ -61,16 +62,29 @@
         display: flex;
         flex-wrap: wrap;
         align-items: center;
-        gap: 0.5rem;
+        column-gap: 0.5rem;
+        row-gap: 0.35rem;
     }
 
     .task-toggle {
         min-width: 0;
+        color: var(--bs-secondary-color, var(--bs-body-color));
+        transition: color 0.15s ease-in-out;
+    }
+
+    .task-toggle:hover,
+    .task-toggle:focus {
+        color: var(--bs-body-color);
     }
 
     .task-title {
-        color: inherit;
+        color: var(--bs-secondary-color, var(--bs-body-color));
         min-width: 0;
+        font-weight: 500;
+    }
+
+    .task-title del {
+        color: inherit;
     }
 
     .tag-section-label {
@@ -123,6 +137,7 @@
 
     .task-description {
         white-space: pre-wrap;
+        color: var(--bs-secondary-color, var(--bs-body-color));
     }
 
     .inline-tag-input-group .form-control {
@@ -225,14 +240,25 @@
 
     .task-action-group {
         display: flex;
-        flex-wrap: wrap;
+        flex-wrap: nowrap;
         gap: 0.35rem;
         margin-left: auto;
         justify-content: flex-end;
+        flex: 0 0 auto;
+        white-space: nowrap;
+        align-self: center;
     }
 
     .task-action-group .task-action-btn {
         border-radius: 0.5rem;
+    }
+
+    @media (max-width: 767.98px) {
+        .task-action-group {
+            width: 100%;
+            margin-left: 0;
+            justify-content: flex-start;
+        }
     }
 
     .task-group-add-btn {
@@ -333,32 +359,23 @@
                 <button id="quick-cancel-btn" class="btn btn-secondary" type="reset">
                     <i class="bi bi-x-circle"></i>
                 </button>
-                {% if task_form.name.errors %}
-                    {% for error in task_form.name.errors %}
-                        <div class="invalid-feedback" style="display:block;">{{ error }}</div>
-                    {% endfor %}
-                {% endif %}
+                {% set name_error = task_form.name.errors[0] if task_form.name.errors else '' %}
+                <div class="invalid-feedback {% if not name_error %}d-none{% endif %}" data-feedback-for="name">{{ name_error }}</div>
             </div>
         </div>
         <div id="detailed-item-container" class="accordion-collapse collapse" data-bs-parent="#quick-item-accordion">
             <div class="accordion-body">
                 <div class="form-floating mb-3">
-                    {{ task_form.description(class_='form-control auto-resize-textarea', rows=3, placeholder_='Add more details') }}
+                    {{ task_form.description(class_='form-control auto-resize-textarea'+ (' is-invalid' if task_form.description.errors else ''), rows=3, placeholder_='Add more details') }}
                     {{ task_form.description.label(class_='form-label') }}
-                    {% if task_form.description.errors %}
-                        {% for error in task_form.description.errors %}
-                            <div class="invalid-feedback" style="display:block;">{{ error }}</div>
-                        {% endfor %}
-                    {% endif %}
+                    {% set description_error = task_form.description.errors[0] if task_form.description.errors else '' %}
+                    <div class="invalid-feedback {% if not description_error %}d-none{% endif %}" data-feedback-for="description">{{ description_error }}</div>
                 </div>
                 <div class="form-floating mb-3">
-                    {{ task_form.end_date(class_='form-control') }}
+                    {{ task_form.end_date(class_='form-control'+ (' is-invalid' if task_form.end_date.errors else ''), placeholder_='Add more details') }}
                     {{ task_form.end_date.label(class_='form-label') }}
-                    {% if task_form.end_date.errors %}
-                        {% for error in task_form.end_date.errors %}
-                            <div class="invalid-feedback" style="display:block;">{{ error }}</div>
-                        {% endfor %}
-                    {% endif %}
+                    {% set end_date_error = task_form.end_date.errors[0] if task_form.end_date.errors else '' %}
+                    <div class="invalid-feedback {% if not end_date_error %}d-none{% endif %}" data-feedback-for="end_date">{{ end_date_error }}</div>
                 </div>
                 <div class="mb-3">
                     <div class="d-flex flex-wrap gap-2" id="task-inline-tag-options"></div>
@@ -475,7 +492,9 @@
         updateChevronForCollapse(event.target.id, false);
     });
 
+    const defaultTaskAction = '{{ url_for("add_task") }}';
     const taskForm = document.getElementById('task-form');
+    const quickAddBtn = document.getElementById('quick-add-btn');
     const quickCancelBtn = document.getElementById('quick-cancel-btn');
     const nameField = document.getElementById('name');
     const descriptionField = document.getElementById('description');
@@ -511,6 +530,56 @@
         setQuickToggleIcon(detailedItemContainer.classList.contains('show'));
         detailedItemContainer.addEventListener('show.bs.collapse', () => setQuickToggleIcon(true));
         detailedItemContainer.addEventListener('hide.bs.collapse', () => setQuickToggleIcon(false));
+    }
+
+    function getTaskFormAction() {
+        if (!taskForm) {
+            return defaultTaskAction;
+        }
+        return taskForm.getAttribute('action') || defaultTaskAction;
+    }
+
+    function isEditingCurrentTask() {
+        const action = getTaskFormAction();
+        return typeof action === 'string' && action.includes('/task/edit/');
+    }
+
+    function setTaskFormActionToAdd() {
+        if (taskForm) {
+            taskForm.action = defaultTaskAction;
+        }
+    }
+
+    function applyTaskFormErrors(errors = {}) {
+        if (!taskForm) {
+            return;
+        }
+        const fieldConfigs = [
+            { element: nameField, key: 'name' },
+            { element: descriptionField, key: 'description' },
+            { element: endDateField, key: 'end_date' },
+        ];
+
+        fieldConfigs.forEach(({ element, key }) => {
+            if (!element) {
+                return;
+            }
+            const feedback = taskForm.querySelector(`[data-feedback-for="${key}"]`);
+            const messages = Array.isArray(errors[key]) ? errors[key] : [];
+            if (messages.length > 0) {
+                element.classList.add('is-invalid');
+                if (feedback) {
+                    feedback.textContent = messages[0];
+                    feedback.classList.remove('d-none');
+                }
+            } else {
+                element.classList.remove('is-invalid');
+                if (feedback) {
+                    feedback.textContent = '';
+                    feedback.classList.add('d-none');
+                }
+            }
+        });
     }
 
     function convertToLocal(utcDateString) {
@@ -739,6 +808,90 @@
         if (inlineTagFeedback) {
             inlineTagFeedback.classList.add('d-none');
         }
+    }
+
+    function handleTaskFormSubmit(event) {
+        if (!taskForm) {
+            return;
+        }
+        if (event) {
+            event.preventDefault();
+            if (event.submitter && event.submitter.type === 'reset') {
+                return;
+            }
+        }
+        if (taskForm.dataset.ajaxSubmitting === 'true') {
+            return;
+        }
+
+        applyTaskFormErrors({});
+        const formData = new FormData(taskForm);
+        if (formData.has('name')) {
+            formData.set('name', (formData.get('name') || '').trim());
+        }
+
+        taskForm.dataset.ajaxSubmitting = 'true';
+        if (quickAddBtn) {
+            quickAddBtn.disabled = true;
+        }
+
+        const actionUrl = getTaskFormAction();
+
+        fetch(actionUrl, {
+            method: 'POST',
+            body: formData,
+            headers: {
+                'X-Requested-With': 'XMLHttpRequest',
+                Accept: 'application/json',
+            },
+        })
+            .then((response) =>
+                response
+                    .json()
+                    .catch(() => ({}))
+                    .then((data) => ({ ok: response.ok, data }))
+            )
+            .then(({ ok, data }) => {
+                if (!ok || !data || data.success !== true) {
+                    const errors = (data && data.errors) || {};
+                    applyTaskFormErrors(errors);
+                    const message = (data && data.message) || 'Unable to save task.';
+                    displayFlashMessage(message, 'danger');
+                    const error = new Error(message);
+                    error.silent = true;
+                    throw error;
+                }
+
+                applyTaskFormErrors({});
+                const message = data.message || (isEditingCurrentTask() ? 'Task updated!' : 'Task added!');
+                displayFlashMessage(message, 'success');
+
+                taskForm.reset();
+                clearInlineSelection();
+                collapseAccordionItem('detailed-item-container');
+                if (descriptionField) {
+                    descriptionField.style.height = '';
+                }
+                setTaskFormActionToAdd();
+
+                return refreshTaskList().then(() => {
+                    if (nameField) {
+                        nameField.focus({ preventScroll: false });
+                        nameField.select();
+                    }
+                });
+            })
+            .catch((error) => {
+                if (!error || !error.silent) {
+                    console.error('Task form submission failed', error);
+                }
+            })
+            .finally(() => {
+                if (quickAddBtn) {
+                    quickAddBtn.disabled = false;
+                }
+                taskForm.dataset.ajaxSubmitting = 'false';
+            });
     }
 
     function focusTaskFormForGroup({ tagIdValue = null, dueBucket = null } = {}) {
@@ -1223,40 +1376,48 @@
         }
         const tagName = button.dataset.tagName || '';
         const tagCount = Number(button.dataset.tagCount || '0');
-        if (tagCount > 0) {
-            const confirmed = window.confirm(
-                `Tag "#${tagName}" is assigned to ${tagCount} task${tagCount === 1 ? '' : 's'}. Delete it?`
-            );
+        const proceed = tagCount > 0 && typeof showConfirmationModal === 'function'
+            ? showConfirmationModal({
+                  title: 'Delete tag',
+                  message: `Tag "#${tagName}" is assigned to ${tagCount} task${tagCount === 1 ? '' : 's'}. Delete it?`,
+                  confirmLabel: 'Delete tag',
+                  confirmVariant: 'danger',
+              })
+            : Promise.resolve(true);
+
+        Promise.resolve(proceed).then((confirmed) => {
             if (!confirmed) {
                 return;
             }
-        }
-        fetch(`/tags/${tagId}`, {
-            method: 'DELETE',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': csrfToken,
-            },
-        })
-            .then((response) => {
-                if (!response.ok) {
-                    throw response;
-                }
-                return response.json();
+            fetch(`/tags/${tagId}`, {
+                method: 'DELETE',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': csrfToken,
+                },
             })
-            .then(() => {
-                button.remove();
-                availableTagsMap.delete(String(tagId));
-                updateFilterEmptyState();
-                inlineSelectedTags.delete(String(tagId));
-                syncInlineTagsField();
-                renderInlineTagOptions();
-                applyTagFilters();
-                refreshTaskList();
-            })
-            .catch((error) => {
-                console.error('Unable to delete tag', error);
-            });
+                .then((response) => {
+                    if (!response.ok) {
+                        throw response;
+                    }
+                    return response.json();
+                })
+                .then(() => {
+                    button.remove();
+                    availableTagsMap.delete(String(tagId));
+                    updateFilterEmptyState();
+                    inlineSelectedTags.delete(String(tagId));
+                    syncInlineTagsField();
+                    renderInlineTagOptions();
+                    applyTagFilters();
+                    refreshTaskList();
+                    displayFlashMessage(`Tag "#${tagName}" deleted.`, 'success');
+                })
+                .catch((error) => {
+                    console.error('Unable to delete tag', error);
+                    displayFlashMessage(`Unable to delete tag "#${tagName}".`, 'danger');
+                });
+        });
     }
 
     // Use WeakSet to track attached listeners for edit-task-btn
@@ -1296,8 +1457,67 @@
                     taskForm.action = actionUrl;
                 }
 
+                applyTaskFormErrors({});
                 expandAccordionItem('detailed-item-container');
                 window.scrollTo({ top: 0, behavior: 'smooth' });
+            });
+        });
+    }
+
+    const taskDeleteListenerAttached = new WeakSet();
+    function attachTaskDeleteListeners() {
+        document.querySelectorAll('.task-delete-btn').forEach((button) => {
+            if (taskDeleteListenerAttached.has(button)) {
+                return;
+            }
+            taskDeleteListenerAttached.add(button);
+            button.addEventListener('click', (event) => {
+                event.preventDefault();
+                if (typeof showConfirmationModal !== 'function') {
+                    return;
+                }
+                const actionUrl = button.dataset.confirmUrl;
+                if (!actionUrl) {
+                    return;
+                }
+                const taskName = button.dataset.taskName || button.getAttribute('aria-label') || 'this task';
+                showConfirmationModal({
+                    title: 'Delete task',
+                    message: `Delete "${taskName}"? This action cannot be undone.`,
+                    confirmLabel: 'Delete task',
+                    confirmVariant: 'danger',
+                }).then((confirmed) => {
+                    if (!confirmed) {
+                        return;
+                    }
+                    fetch(actionUrl, {
+                        method: 'POST',
+                        headers: {
+                            'X-Requested-With': 'XMLHttpRequest',
+                            Accept: 'application/json',
+                        },
+                    })
+                        .then((response) =>
+                            response
+                                .json()
+                                .catch(() => ({}))
+                                .then((data) => ({ ok: response.ok, data }))
+                        )
+                        .then(({ ok, data }) => {
+                            if (!ok || !data || data.success !== true) {
+                                const message = (data && data.message) || `Unable to delete "${taskName}".`;
+                                displayFlashMessage(message, 'danger');
+                                return;
+                            }
+                            const message = (data && data.message) || `Task "${taskName}" deleted.`;
+                            displayFlashMessage(message, 'success');
+                            refreshTaskList();
+                        })
+                        .catch((error) => {
+                            console.error('Unable to delete task', error);
+                            displayFlashMessage(`Unable to delete "${taskName}".`, 'danger');
+                        });
+                });
             });
         });
     }
@@ -1350,24 +1570,25 @@
 
     if (quickCancelBtn) {
         quickCancelBtn.addEventListener('click', () => {
-            const actionUrl = '{{ url_for("add_task") }}';
-            if (taskForm) {
-                taskForm.action = actionUrl;
-            }
+            setTaskFormActionToAdd();
             clearInlineSelection();
             collapseAccordionItem('detailed-item-container');
+            applyTaskFormErrors({});
         });
     }
 
     if (taskForm) {
         taskForm.addEventListener('reset', () => {
-            const actionUrl = '{{ url_for("add_task") }}';
-            taskForm.action = actionUrl;
+            setTaskFormActionToAdd();
             clearInlineSelection();
+            applyTaskFormErrors({});
             if (descriptionField) {
                 descriptionField.style.height = '';
             }
         });
+        if (typeof window.fetch === 'function') {
+            taskForm.addEventListener('submit', handleTaskFormSubmit);
+        }
     }
 
     document.querySelectorAll('textarea.auto-resize-textarea').forEach((textarea) => {
@@ -1438,6 +1659,7 @@
                 initializeSortableGroups();
                 attachEditTaskListeners();
                 attachTagManagerListeners();
+                attachTaskDeleteListeners();
                 attachGroupAddListeners();
                 syncChevronStates();
                 updateDateDisplays();
@@ -1453,6 +1675,7 @@
     setInlineTagsFromString(tagsField ? tagsField.value : '');
     attachEditTaskListeners();
     attachTagManagerListeners();
+    attachTaskDeleteListeners();
     attachGroupAddListeners();
     applyTagFilters();
     updateDateDisplays();


### PR DESCRIPTION
## Summary
- restyle the shared modals to match the tags modal and replace window alerts/confirms with a reusable confirmation modal
- convert task create/edit/delete flows to AJAX with JSON responses so filter state is preserved and flash messaging references task names
- tweak task list styling by keeping action icons in a single row, softening text colors, and moving quick-add buttons beside group headers while applying the same confirmation flow to scope actions

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_b_68dd441637888330a511b94ab482d5d7