### PR TITLE
Refine confirmation modals and quick add controls

### DIFF
--- a/templates/components/task_groups.html
+++ b/templates/components/task_groups.html
@@ -72,6 +72,11 @@
                                     <button type="button" class="btn task-action-btn task-delete-btn"
                                         data-confirm-url="{{ url_for('delete_item', item_type='task', id=task.id) }}"
                                         data-task-name="{{ task.name | e }}"
+                                        data-task-completed="{{ 'true' if task.completed else 'false' }}"
+                                        {% if task.completed_date %}data-task-completed-date="{{ task.completed_date.isoformat() }}"{% endif %}
+                                        {% if task.end_date %}data-task-due-date="{{ task.end_date.isoformat() }}"{% endif %}
+                                        data-task-tag-count="{{ task.tags | length }}"
+                                        data-task-tags='{{ task.tags | map(attribute="name") | list | tojson | e }}'
                                         aria-label="Delete task {{ task.name }}">
                                         <i class="bi bi-trash"></i>
                                     </button>

--- a/templates/modals/confirmation_modal.html
+++ b/templates/modals/confirmation_modal.html
@@ -1,14 +1,16 @@
 <div class="modal fade" id="confirmationModal" tabindex="-1" aria-labelledby="confirmationModalTitle" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered modal-sm">
+    <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
             <div class="modal-header border-0 pb-0">
                 <h5 class="modal-title" id="confirmationModalTitle">Confirm action</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <div class="modal-body">
-                <p class="mb-0" id="confirmationModalBody">Are you sure you want to continue?</p>
+            <div class="modal-body pt-2">
+                <p class="mb-1 fw-semibold" id="confirmationModalMessage">Are you sure you want to continue?</p>
+                <p class="text-muted small mb-3" id="confirmationModalDescription">This action cannot be undone.</p>
+                <ul class="text-muted small mb-0 ps-3 d-none" id="confirmationModalDetails"></ul>
             </div>
-            <div class="modal-footer border-0 pt-0">
+            <div class="modal-footer border-0 pt-0 gap-2">
                 <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
                 <button type="button" class="btn btn-danger" id="confirmButton">Confirm</button>
             </div>
@@ -24,17 +26,23 @@
     }
 
     const modalTitle = document.getElementById('confirmationModalTitle');
-    const modalBody = document.getElementById('confirmationModalBody');
+    const modalMessage = document.getElementById('confirmationModalMessage');
+    const modalDescription = document.getElementById('confirmationModalDescription');
+    const modalDetails = document.getElementById('confirmationModalDetails');
     const confirmButton = document.getElementById('confirmButton');
-    const modalInstance = new bootstrap.Modal(modalElement);
-
+    let modalInstance = null;
     let resolver = null;
     let wasConfirmed = false;
     const defaultConfirmClass = 'btn btn-danger';
 
     confirmButton.addEventListener('click', () => {
         wasConfirmed = true;
-        modalInstance.hide();
+        const instance = ensureModalInstance();
+        if (instance) {
+            instance.hide();
+        } else {
+            wasConfirmed = false;
+        }
     });
 
     modalElement.addEventListener('hidden.bs.modal', () => {
@@ -45,19 +53,65 @@
         resolver = null;
         confirmButton.className = defaultConfirmClass;
         confirmButton.textContent = 'Confirm';
+        if (modalMessage) {
+            modalMessage.textContent = 'Are you sure you want to continue?';
+        }
+        if (modalDescription) {
+            modalDescription.textContent = 'This action cannot be undone.';
+            modalDescription.classList.remove('d-none');
+        }
+        if (modalDetails) {
+            modalDetails.innerHTML = '';
+            modalDetails.classList.add('d-none');
+        }
     });
+
+    function ensureModalInstance() {
+        if (modalInstance) {
+            return modalInstance;
+        }
+        if (typeof bootstrap === 'undefined' || !bootstrap.Modal) {
+            console.warn('Confirmation modal requires Bootstrap.');
+            return null;
+        }
+        modalInstance = new bootstrap.Modal(modalElement);
+        return modalInstance;
+    }
 
     window.showConfirmationModal = function showConfirmationModal({
         title = 'Confirm action',
         message = 'Are you sure you want to continue?',
+        description = 'This action cannot be undone.',
+        details = [],
         confirmLabel = 'Confirm',
         confirmVariant = 'danger',
     } = {}) {
         if (modalTitle) {
             modalTitle.textContent = title;
         }
-        if (modalBody) {
-            modalBody.textContent = message;
+        if (modalMessage) {
+            modalMessage.textContent = message;
+        }
+        if (modalDescription) {
+            const hasDescription = typeof description === 'string' && description.trim().length > 0;
+            modalDescription.textContent = hasDescription ? description : '';
+            modalDescription.classList.toggle('d-none', !hasDescription);
+        }
+        if (modalDetails) {
+            modalDetails.innerHTML = '';
+            const normalizedDetails = Array.isArray(details)
+                ? details.filter((detail) => typeof detail === 'string' && detail.trim().length > 0)
+                : [];
+            if (normalizedDetails.length > 0) {
+                normalizedDetails.forEach((detail) => {
+                    const item = document.createElement('li');
+                    item.textContent = detail;
+                    modalDetails.appendChild(item);
+                });
+                modalDetails.classList.remove('d-none');
+            } else {
+                modalDetails.classList.add('d-none');
+            }
         }
         if (confirmButton) {
             const normalizedVariant = (confirmVariant || 'danger').trim();
@@ -71,7 +125,11 @@
             confirmButton.textContent = confirmLabel;
         }
 
-        modalInstance.show();
+        const instance = ensureModalInstance();
+        if (!instance) {
+            return Promise.resolve(false);
+        }
+        instance.show();
         return new Promise((resolve) => {
             resolver = resolve;
         });

--- a/templates/scope.html
+++ b/templates/scope.html
@@ -77,7 +77,9 @@
             const scopeName = button.dataset.scopeName || 'this scope';
             showConfirmationModal({
                 title: 'Delete scope',
-                message: `Delete scope "${scopeName}"? This action cannot be undone.`,
+                message: `Delete scope "${scopeName}"?`,
+                description: 'Deleting this scope will remove it permanently.',
+                details: ['This action cannot be undone.'],
                 confirmLabel: 'Delete scope',
                 confirmVariant: 'danger',
             }).then((confirmed) => {

--- a/templates/task.html
+++ b/templates/task.html
@@ -262,10 +262,20 @@
     }
 
     .task-group-add-btn {
+        --task-quick-add-scale: 0.75;
         display: inline-flex;
         align-items: center;
         justify-content: center;
         gap: 0.25rem;
+        --bs-btn-padding-y: calc(0.25rem * var(--task-quick-add-scale));
+        --bs-btn-padding-x: calc(0.5rem * var(--task-quick-add-scale));
+        --bs-btn-font-size: calc(0.875rem * var(--task-quick-add-scale));
+        --bs-btn-line-height: 1;
+        --bs-btn-border-radius: calc(0.2rem * var(--task-quick-add-scale));
+    }
+
+    .task-group-add-btn .bi {
+        font-size: calc(1rem * var(--task-quick-add-scale));
     }
 
     .task-filter-collapse.collapse:not(.show) {
@@ -1379,7 +1389,12 @@
         const proceed = tagCount > 0 && typeof showConfirmationModal === 'function'
             ? showConfirmationModal({
                   title: 'Delete tag',
-                  message: `Tag "#${tagName}" is assigned to ${tagCount} task${tagCount === 1 ? '' : 's'}. Delete it?`,
+                  message: `Delete "#${tagName}"?`,
+                  description: 'Removing this tag will detach it from every associated task.',
+                  details: [
+                      `${tagCount} task${tagCount === 1 ? '' : 's'} currently use this tag.`,
+                      'This action cannot be undone.',
+                  ],
                   confirmLabel: 'Delete tag',
                   confirmVariant: 'danger',
               })
@@ -1481,9 +1496,54 @@
                     return;
                 }
                 const taskName = button.dataset.taskName || button.getAttribute('aria-label') || 'this task';
+                const detailItems = [];
+                const dueDate = button.dataset.taskDueDate;
+                const formattedDue = typeof formatDateTimeDisplay === 'function'
+                    ? formatDateTimeDisplay(dueDate)
+                    : '';
+                if (formattedDue) {
+                    detailItems.push(`Due ${formattedDue}`);
+                }
+
+                const tagCount = Number(button.dataset.taskTagCount || '0');
+                if (tagCount > 0) {
+                    let tagNames = [];
+                    try {
+                        tagNames = JSON.parse(button.dataset.taskTags || '[]');
+                    } catch (error) {
+                        tagNames = [];
+                    }
+                    if (Array.isArray(tagNames) && tagNames.length > 0) {
+                        const formattedTags = tagNames
+                            .map((name) => (typeof name === 'string' && name.trim() ? `#${name.trim()}` : null))
+                            .filter(Boolean)
+                            .join(', ');
+                        if (formattedTags) {
+                            detailItems.push(`Tags: ${formattedTags}`);
+                        }
+                    }
+                    if (!detailItems.some((item) => item.startsWith('Tags'))) {
+                        detailItems.push(`${tagCount} tag${tagCount === 1 ? '' : 's'} assigned.`);
+                    }
+                }
+
+                if (button.dataset.taskCompleted === 'true') {
+                    const completedDate = button.dataset.taskCompletedDate;
+                    const formattedCompleted = typeof formatDateTimeDisplay === 'function'
+                        ? formatDateTimeDisplay(completedDate)
+                        : '';
+                    detailItems.push(
+                        formattedCompleted
+                            ? `Completed ${formattedCompleted}`
+                            : 'Task is already marked as completed.'
+                    );
+                }
+
                 showConfirmationModal({
                     title: 'Delete task',
-                    message: `Delete "${taskName}"? This action cannot be undone.`,
+                    message: `Delete "${taskName}"?`,
+                    description: 'Deleting this task will remove it permanently.',
+                    details: [...detailItems, 'This action cannot be undone.'],
                     confirmLabel: 'Delete task',
                     confirmVariant: 'danger',
                 }).then((confirmed) => {


### PR DESCRIPTION
## Summary
- scale down grouped quick-add buttons for better balance with list headers
- restyle the shared confirmation modal to match the manage tags dialog and support contextual descriptions/details
- surface task metadata for delete actions so the modal can show due dates, tag usage, and completion status

## Testing
- not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_b_68dd5d0124908330977823fa793a511c