### PR TITLE
Refine dialog modals and add task shortcuts

### DIFF
--- a/templates/modals/confirmation_modal.html
+++ b/templates/modals/confirmation_modal.html
@@ -1,16 +1,16 @@
 <div class="modal fade" id="confirmationModal" tabindex="-1" aria-labelledby="confirmationModalTitle" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
-            <div class="modal-header border-0 pb-0">
+            <div class="modal-header">
                 <h5 class="modal-title" id="confirmationModalTitle">Confirm action</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <div class="modal-body pt-2">
-                <p class="mb-1 fw-semibold" id="confirmationModalMessage">Are you sure you want to continue?</p>
-                <p class="text-muted small mb-3" id="confirmationModalDescription">This action cannot be undone.</p>
+            <div class="modal-body">
+                <p class="mb-1 fw-semibold" id="confirmationModalMessage">Are you sure you want to proceed?</p>
+                <p class="text-muted small mb-3" id="confirmationModalDescription">Review the details below before continuing.</p>
                 <ul class="text-muted small mb-0 ps-3 d-none" id="confirmationModalDetails"></ul>
             </div>
-            <div class="modal-footer border-0 pt-0 gap-2">
+            <div class="modal-footer gap-2">
                 <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
                 <button type="button" class="btn btn-danger" id="confirmButton">Confirm</button>
             </div>
@@ -34,6 +34,8 @@
     let resolver = null;
     let wasConfirmed = false;
     const defaultConfirmClass = 'btn btn-danger';
+    const defaultMessage = 'Are you sure you want to proceed?';
+    const defaultDescription = 'Review the details below before continuing.';
 
     confirmButton.addEventListener('click', () => {
         wasConfirmed = true;
@@ -54,10 +56,10 @@
         confirmButton.className = defaultConfirmClass;
         confirmButton.textContent = 'Confirm';
         if (modalMessage) {
-            modalMessage.textContent = 'Are you sure you want to continue?';
+            modalMessage.textContent = defaultMessage;
         }
         if (modalDescription) {
-            modalDescription.textContent = 'This action cannot be undone.';
+            modalDescription.textContent = defaultDescription;
             modalDescription.classList.remove('d-none');
         }
         if (modalDetails) {
@@ -80,8 +82,8 @@
 
     window.showConfirmationModal = function showConfirmationModal({
         title = 'Confirm action',
-        message = 'Are you sure you want to continue?',
-        description = 'This action cannot be undone.',
+        message = defaultMessage,
+        description = defaultDescription,
         details = [],
         confirmLabel = 'Confirm',
         confirmVariant = 'danger',

--- a/templates/modals/login_modal.html
+++ b/templates/modals/login_modal.html
@@ -1,12 +1,12 @@
 <div class="modal fade" id="loginModal" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered modal-sm">
         <div class="modal-content">
-            <div class="modal-header border-0 pb-0">
+            <div class="modal-header">
                 <h5 class="modal-title">Sign in</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <div class="modal-body pt-2">
-                <p class="text-muted small mb-3">Enter your credentials to access Projects Manager.</p>
+            <div class="modal-body">
+                <p class="text-muted small mb-3">Sign in with your credentials to open your Projects Manager workspace.</p>
                 {% include 'forms/login_form.html' %}
             </div>
         </div>

--- a/templates/modals/scope_modal.html
+++ b/templates/modals/scope_modal.html
@@ -2,7 +2,7 @@
     <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
 
-            <div class="modal-header border-0 pb-0">
+            <div class="modal-header">
                 <h5 class="modal-title" id="scope-modal-title">Create scope</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
@@ -10,8 +10,8 @@
             <form id="scope-form" method="post">
             {{ scope_form.hidden_tag() }}
 
-            <div class="modal-body pt-2">
-                <p class="text-muted small mb-3" id="scope-modal-description">Organize tasks by creating a new scope.</p>
+            <div class="modal-body">
+                <p class="text-muted small mb-3" id="scope-modal-description">Group related tasks by creating a new scope.</p>
                 <div class="form-floating mb-3">
                     {{ scope_form.name(class_='form-control'+ (' is-invalid' if scope_form.name.errors else ''), placeholder_=scope_form.name.name) }}
                     {{ scope_form.name.label(class="form-label") }}
@@ -32,7 +32,7 @@
                 </div>
             </div>
 
-            <div class="modal-footer border-0 pt-0">
+            <div class="modal-footer">
                 <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">
                 Cancel
                 </button>
@@ -63,20 +63,33 @@
         }
     }
 
+    function buildCreateScopeDescription() {
+        return 'Provide a name and optional description to group related tasks.';
+    }
+
+    function buildEditScopeDescription(name = '') {
+        if (name && name.trim().length > 0) {
+            return `Update the details for "${name.trim()}" before saving your changes.`;
+        }
+        return 'Update the scope details before saving your changes.';
+    }
+
     document.addEventListener('DOMContentLoaded', () => {
         const defaultAction = '{{ url_for("add_scope") }}';
         if (scopeForm) {
             const currentAction = scopeForm.getAttribute('action') || defaultAction;
             if (currentAction !== defaultAction) {
+                const currentNameField = scopeForm.querySelector('#name');
+                const currentName = currentNameField ? currentNameField.value : '';
                 setScopeModalContent({
                     title: 'Edit scope',
-                    description: 'Update the scope details below.',
+                    description: buildEditScopeDescription(currentName),
                     submitLabel: 'Save changes',
                 });
             } else {
                 setScopeModalContent({
                     title: 'Create scope',
-                    description: 'Organize tasks by creating a new scope.',
+                    description: buildCreateScopeDescription(),
                     submitLabel: 'Create scope',
                 });
             }
@@ -95,7 +108,7 @@
             scopeForm.reset();
             setScopeModalContent({
                 title: 'Create scope',
-                description: 'Organize tasks by creating a new scope.',
+                description: buildCreateScopeDescription(),
                 submitLabel: 'Create scope',
             });
         });
@@ -120,7 +133,7 @@
 
             setScopeModalContent({
                 title: 'Edit scope',
-                description: 'Update the scope details below.',
+                description: buildEditScopeDescription(item.getAttribute('data-scope-name') || ''),
                 submitLabel: 'Save changes',
             });
         });

--- a/templates/modals/task_modal.html
+++ b/templates/modals/task_modal.html
@@ -2,7 +2,7 @@
     <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
 
-            <div class="modal-header border-0 pb-0">
+            <div class="modal-header">
                 <h5 class="modal-title" id="task-modal-title">{{ action }} Task</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
@@ -10,8 +10,8 @@
             <form id="task-form" method="post">
             {{ task_form.hidden_tag() }}
 
-            <div class="modal-body pt-2">
-                <p class="text-muted small mb-3" id="task-modal-description">Capture the details for this task below.</p>
+            <div class="modal-body">
+                <p class="text-muted small mb-3" id="task-modal-description">Capture or update the essential details for this task.</p>
                 <div class="form-floating mb-3">
                     {{ task_form.name(class_='form-control'+ (' is-invalid' if task_form.name.errors else ''), placeholder_=task_form.name.name) }}
                     {{ task_form.name.label(class="form-label") }}
@@ -41,7 +41,7 @@
                 </div>
             </div>
 
-            <div class="modal-footer border-0 pt-0">
+            <div class="modal-footer">
                 <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">
                 Cancel
                 </button>
@@ -59,35 +59,99 @@
     // Display the modal based on the flag.
     // Used when validation of the form fails to display the modal by default.
     // Sets the modal butons depending on the action clicked (ADD or EDIT)
+    const taskForm = document.getElementById('task-form');
+    const taskModalTitle = document.getElementById('task-modal-title');
+    const taskModalDescription = document.getElementById('task-modal-description');
+    const taskSubmitButton = document.getElementById('submitTaskButton');
+
+    function setTaskModalContent({ title, description, submitLabel }) {
+        if (taskModalTitle) {
+            taskModalTitle.textContent = title;
+        }
+        if (taskModalDescription) {
+            taskModalDescription.textContent = description;
+        }
+        if (taskSubmitButton) {
+            taskSubmitButton.textContent = submitLabel;
+        }
+    }
+
+    function getTaskNameField() {
+        return document.getElementById('name');
+    }
+
+    function buildCreateTaskDescription() {
+        return 'Capture the essential details to create a new task.';
+    }
+
+    function buildEditTaskDescription(name = '') {
+        if (name && name.trim().length > 0) {
+            return `Update the details for "${name.trim()}" before saving your changes.`;
+        }
+        return 'Update the task details before saving your changes.';
+    }
+
     document.addEventListener('DOMContentLoaded', (event) => {
         {% if show_modal %}
             var modal = new bootstrap.Modal(document.getElementById('{{show_modal}}'));
             modal.show();
         {% endif %}
+
+        const nameField = getTaskNameField();
+        if (taskForm && taskForm.getAttribute('action') && taskForm.getAttribute('action').includes('/task/edit/')) {
+            setTaskModalContent({
+                title: 'Edit task',
+                description: buildEditTaskDescription(nameField ? nameField.value : ''),
+                submitLabel: 'Save changes',
+            });
+        } else {
+            setTaskModalContent({
+                title: 'Add task',
+                description: buildCreateTaskDescription(),
+                submitLabel: 'Save task',
+            });
+        }
     });
 
     // Update the form action when the ADD button is clicked
     // Clears the form fields
-    document.getElementById("add-task-btn").addEventListener("click", (event) => {
-        actionUrl = '{{ url_for("add_task") }}';
-        document.querySelector("#task-form").action = actionUrl;
-        document.getElementById("task-form").reset();
-        //clearFormFields();
-    });
+    const addTaskButton = document.getElementById('add-task-btn');
+    if (addTaskButton && taskForm) {
+        addTaskButton.addEventListener('click', (event) => {
+            const actionUrl = '{{ url_for("add_task") }}';
+            taskForm.action = actionUrl;
+            taskForm.reset();
+            setTaskModalContent({
+                title: 'Add task',
+                description: buildCreateTaskDescription(),
+                submitLabel: 'Save task',
+            });
+        });
+    }
 
     // Update the modal form action when the EDIT button is clicked
     // Populate the form with the values associated to the EDIT button
-    document.querySelectorAll(".edit-task-btn").forEach((item) => {
-        item.addEventListener("click", (event) => {
+    document.querySelectorAll('.edit-task-btn').forEach((item) => {
+        item.addEventListener('click', (event) => {
             {% for field in task_form %}
                 {% if field.name != 'csrf_token' and field.type != 'SubmitField' %}
-                    document.getElementById('{{ field.name }}').value = item.getAttribute("data-task-{{ field.name }}");
+                    const fieldElement = document.getElementById('{{ field.name }}');
+                    if (fieldElement) {
+                        fieldElement.value = item.getAttribute('data-task-{{ field.name }}');
+                    }
                 {% endif %}
             {% endfor %}
 
-            let baseUrl = '{{ url_for("edit_task", id=0) }}';
-            let actionUrl = baseUrl.replace("/0", "/" + item.getAttribute("data-task-id"));
-            document.querySelector("#task-form").action = actionUrl;
+            if (taskForm) {
+                const baseUrl = '{{ url_for("edit_task", id=0) }}';
+                const actionUrl = baseUrl.replace('/0', `/${item.getAttribute('data-task-id')}`);
+                taskForm.action = actionUrl;
+            }
+            setTaskModalContent({
+                title: 'Edit task',
+                description: buildEditTaskDescription(item.getAttribute('data-task-name') || ''),
+                submitLabel: 'Save changes',
+            });
         });
     });
 
@@ -100,17 +164,19 @@
     };
 
     // Convert DateTimeLocalField to UTC before to to submit the form
-    document.getElementById('task-form').addEventListener('submit', function(event) {
-        event.preventDefault();  // Prevent the default form submission
-        {% for field in task_form %}
-            {% if field.type == 'DateTimeLocalField' %}
-                if (document.getElementById('{{ field.name }}').value != '') {
-                    document.getElementById('{{ field.name }}').value = convertToUTC(document.getElementById('{{ field.name }}').value)
-                }
-            {% endif %}
-        {% endfor %}
-        this.submit();
-    });
+    if (taskForm) {
+        taskForm.addEventListener('submit', function(event) {
+            event.preventDefault();  // Prevent the default form submission
+            {% for field in task_form %}
+                {% if field.type == 'DateTimeLocalField' %}
+                    if (document.getElementById('{{ field.name }}').value != '') {
+                        document.getElementById('{{ field.name }}').value = convertToUTC(document.getElementById('{{ field.name }}').value)
+                    }
+                {% endif %}
+            {% endfor %}
+            this.submit();
+        });
+    }
 
     function convertToUTC(dateString){
         var localDateTime = new Date(dateString);

--- a/templates/scope.html
+++ b/templates/scope.html
@@ -78,8 +78,8 @@
             showConfirmationModal({
                 title: 'Delete scope',
                 message: `Delete scope "${scopeName}"?`,
-                description: 'Deleting this scope will remove it permanently.',
-                details: ['This action cannot be undone.'],
+                description: `Deleting this scope will permanently remove "${scopeName}" and its ordering.`,
+                details: [`Scope: ${scopeName}`, 'This action cannot be undone.'],
                 confirmLabel: 'Delete scope',
                 confirmVariant: 'danger',
             }).then((confirmed) => {

--- a/templates/task.html
+++ b/templates/task.html
@@ -415,7 +415,8 @@
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
-                    <p class="text-muted small mb-2" id="tag-modal-task-name"></p>
+                    <p class="text-muted small mb-1">Assign or remove tags to keep this task organized.</p>
+                    <p class="fw-semibold mb-3" id="tag-modal-task-name"></p>
                     <div class="mb-3">
                         <div class="d-flex flex-wrap gap-2" id="tag-modal-available"></div>
                         <p class="text-muted small mb-0 d-none" id="tag-modal-empty">No tags yet. Create one below.</p>
@@ -1386,13 +1387,16 @@
         }
         const tagName = button.dataset.tagName || '';
         const tagCount = Number(button.dataset.tagCount || '0');
-        const proceed = tagCount > 0 && typeof showConfirmationModal === 'function'
+        const proceed = typeof showConfirmationModal === 'function'
             ? showConfirmationModal({
                   title: 'Delete tag',
-                  message: `Delete "#${tagName}"?`,
-                  description: 'Removing this tag will detach it from every associated task.',
+                  message: `Delete tag "#${tagName}"?`,
+                  description: `Deleting this tag will remove "#${tagName}" from every associated task.`,
                   details: [
-                      `${tagCount} task${tagCount === 1 ? '' : 's'} currently use this tag.`,
+                      `Tag: #${tagName}`,
+                      tagCount > 0
+                          ? `${tagCount} task${tagCount === 1 ? '' : 's'} currently use this tag.`
+                          : 'This tag is not assigned to any tasks.',
                       'This action cannot be undone.',
                   ],
                   confirmLabel: 'Delete tag',
@@ -1539,10 +1543,11 @@
                     );
                 }
 
+                detailItems.unshift(`Task: ${taskName}`);
                 showConfirmationModal({
                     title: 'Delete task',
-                    message: `Delete "${taskName}"?`,
-                    description: 'Deleting this task will remove it permanently.',
+                    message: `Delete task "${taskName}"?`,
+                    description: `Deleting this task will permanently remove "${taskName}" and its activity.`,
                     details: [...detailItems, 'This action cannot be undone.'],
                     confirmLabel: 'Delete task',
                     confirmVariant: 'danger',
@@ -1598,7 +1603,8 @@
                 currentTaskTags = new Map();
 
                 if (tagModalTaskName) {
-                    tagModalTaskName.textContent = `Tags for "${button.dataset.taskName || ''}"`;
+                    const taskLabel = button.dataset.taskName || 'this task';
+                    tagModalTaskName.textContent = `Task: "${taskLabel}"`;
                 }
 
                 const tagContainer = document.getElementById(`task-tags-${currentTaskId}`);
@@ -1775,6 +1781,58 @@
 
     if (inlineTagAddBtn) {
         inlineTagAddBtn.addEventListener('click', handleInlineTagCreate);
+    }
+
+    function focusNewTask(expandDetails = true) {
+        if (!taskForm) {
+            return;
+        }
+        taskForm.reset();
+        taskForm.dataset.ajaxSubmitting = 'false';
+        const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        taskForm.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth', block: 'start' });
+        if (expandDetails) {
+            if (detailedItemCollapse) {
+                detailedItemCollapse.show();
+            } else {
+                expandAccordionItem('detailed-item-container');
+            }
+        }
+        window.setTimeout(() => {
+            if (nameField) {
+                nameField.focus({ preventScroll: true });
+                nameField.select();
+            }
+        }, 0);
+    }
+
+    document.addEventListener('keydown', (event) => {
+        const isShortcutModifier = event.ctrlKey || event.metaKey;
+        if (!isShortcutModifier) {
+            return;
+        }
+        const key = (event.key || '').toLowerCase();
+        if (key === 'n') {
+            event.preventDefault();
+            focusNewTask(true);
+        }
+    });
+
+    if (nameField) {
+        nameField.addEventListener('keydown', (event) => {
+            if (!(event.ctrlKey || event.metaKey)) {
+                return;
+            }
+            if (event.key !== 'ArrowDown') {
+                return;
+            }
+            event.preventDefault();
+            if (detailedItemCollapse) {
+                detailedItemCollapse.show();
+            } else {
+                expandAccordionItem('detailed-item-container');
+            }
+        });
     }
 
     if (inlineTagInput) {


### PR DESCRIPTION
## Summary
- unify the confirmation, login, scope, and task modals with the Manage Tags styling while updating their copy for clearer guidance
- ensure destructive actions use the shared confirmation modal with descriptive entity details and improved task/tag messaging
- add keyboard shortcuts to create tasks and expand details from the quick-add field for faster entry

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dd62fb16f08330aea1134602f3c383