### PR TITLE
Fix tag selection persistence and adjust dark theme quick add button

### DIFF
--- a/app.py
+++ b/app.py
@@ -872,7 +872,8 @@ def edit_task(id):
     if item.scope_id != g.scope.id or item.owner_id != g.user.id:
         abort(404)
     form = TaskForm(obj=item)
-    form.tags.data = ",".join(str(tag.id) for tag in item.tags)
+    if not form.is_submitted():
+        form.tags.data = ",".join(str(tag.id) for tag in item.tags)
     wants_json = (
         request.headers.get("X-Requested-With") == "XMLHttpRequest"
         or request.accept_mimetypes["application/json"] >= request.accept_mimetypes["text/html"]

--- a/templates/task.html
+++ b/templates/task.html
@@ -847,7 +847,7 @@
         }
 
         applyTaskFormErrors({});
-        syncInlineTagsField();
+        if (typeof syncInlineTagsField === 'function') syncInlineTagsField();
         const formData = new FormData(taskForm);
         if (formData.has('name')) {
             formData.set('name', (formData.get('name') || '').trim());

--- a/templates/task.html
+++ b/templates/task.html
@@ -278,6 +278,17 @@
         font-size: calc(1rem * var(--task-quick-add-scale));
     }
 
+    [data-bs-theme="dark"] .task-group-add-btn {
+        --bs-btn-color: var(--bs-white);
+        --bs-btn-border-color: rgba(255, 255, 255, 0.65);
+        --bs-btn-hover-color: var(--bs-white);
+        --bs-btn-hover-bg: rgba(255, 255, 255, 0.2);
+        --bs-btn-hover-border-color: rgba(255, 255, 255, 0.85);
+        --bs-btn-active-bg: rgba(255, 255, 255, 0.3);
+        --bs-btn-active-border-color: rgba(255, 255, 255, 0.9);
+        color: var(--bs-white);
+    }
+
     .task-filter-collapse.collapse:not(.show) {
         display: none;
     }
@@ -836,6 +847,7 @@
         }
 
         applyTaskFormErrors({});
+        syncInlineTagsField();
         const formData = new FormData(taskForm);
         if (formData.has('name')) {
             formData.set('name', (formData.get('name') || '').trim());


### PR DESCRIPTION
## Summary
- ensure the inline tag picker writes its selection back to the hidden form field before submitting so edits persist
- lighten the quick-add buttons for task groups in the dark theme for better contrast

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e204f51ca08330843fbc6c897f753f