### PR TITLE
Fix tag deletion confirmation counts and sync

### DIFF
--- a/app.py
+++ b/app.py
@@ -562,6 +562,11 @@ def task():
         "sortable_group_ids": sortable_group_ids,
     }
 
+    available_tags_payload = [
+        {"id": tag.id, "name": tag.name, "task_count": tag_usage.get(tag.id, 0)}
+        for tag in available_tags
+    ]
+
     if request.headers.get("X-Requested-With") == "XMLHttpRequest":
         html = render_template(
             "components/task_groups.html",
@@ -572,6 +577,7 @@ def task():
                 "html": html,
                 "sort_by": sort_by,
                 "sortable_group_ids": sortable_group_ids,
+                "available_tags": available_tags_payload,
             }
         )
 

--- a/templates/task.html
+++ b/templates/task.html
@@ -1124,46 +1124,126 @@
         return button;
     }
 
+    function normalizeTagPayload(tag) {
+        if (!tag || tag.id === undefined || tag.id === null) {
+            return null;
+        }
+        const id = Number(tag.id);
+        if (Number.isNaN(id)) {
+            return null;
+        }
+        const name = typeof tag.name === 'string' ? tag.name : '';
+        const rawCount = tag.task_count ?? tag.taskCount ?? tag.count ?? 0;
+        const count = Number(rawCount);
+        return {
+            id,
+            name,
+            task_count: Number.isNaN(count) ? 0 : count,
+        };
+    }
+
     function ensureTagInFilter(tag) {
-        if (!filterContainer || !tag) {
+        if (!filterContainer) {
             return;
         }
-        const tagId = String(tag.id);
-        const normalized = {
-            id: Number(tag.id),
-            name: tag.name,
-            task_count: Number(tag.task_count ?? tag.taskCount ?? tag.count ?? 0),
-        };
+        const normalized = normalizeTagPayload(tag);
+        if (!normalized) {
+            return;
+        }
+        const tagId = String(normalized.id);
         const existing = availableTagsMap.get(tagId);
         if (existing) {
+            existing.name = normalized.name;
             existing.task_count = normalized.task_count;
             const button = filterContainer.querySelector(`.tag-filter-button[data-tag-id="${tagId}"]`);
             if (button) {
+                button.dataset.tagName = normalized.name;
                 button.dataset.tagCount = String(existing.task_count);
+                const label = button.querySelector('.tag-filter-label');
+                if (label) {
+                    label.textContent = `#${normalized.name}`;
+                }
+                const remove = button.querySelector('.tag-filter-remove');
+                if (remove) {
+                    remove.dataset.tagId = tagId;
+                    remove.setAttribute('aria-label', `Delete tag #${normalized.name}`);
+                }
             }
             return;
         }
-        availableTagsMap.set(tagId, normalized);
+        availableTagsMap.set(tagId, { ...normalized });
         const button = createFilterButton(normalized);
         filterContainer.appendChild(button);
         updateFilterEmptyState();
     }
 
-    function adjustFilterTagCount(tagId, delta) {
+    function syncFilterTags(tags = []) {
         if (!filterContainer) {
             return;
         }
-        const button = filterContainer.querySelector(`.tag-filter-button[data-tag-id="${tagId}"]`);
+        const seen = new Set();
+        tags.forEach((tag) => {
+            const normalized = normalizeTagPayload(tag);
+            if (!normalized) {
+                return;
+            }
+            ensureTagInFilter(normalized);
+            seen.add(String(normalized.id));
+        });
+        let updatedSelected = false;
+        filterContainer.querySelectorAll('.tag-filter-button').forEach((button) => {
+            const tagId = button.dataset.tagId;
+            if (!seen.has(tagId)) {
+                availableTagsMap.delete(tagId);
+                inlineSelectedTags.delete(tagId);
+                button.remove();
+                updatedSelected = true;
+            }
+        });
+        if (updatedSelected) {
+            syncInlineTagsField();
+        }
+        updateFilterEmptyState();
+    }
+
+    function getFilterTagCount(tagId) {
+        const key = String(tagId);
+        const tag = availableTagsMap.get(key);
+        if (tag && typeof tag.task_count === 'number' && !Number.isNaN(tag.task_count)) {
+            return tag.task_count;
+        }
+        if (!filterContainer) {
+            return 0;
+        }
+        const button = filterContainer.querySelector(`.tag-filter-button[data-tag-id="${key}"]`);
         if (!button) {
-            return;
+            return 0;
         }
-        const current = Number(button.dataset.tagCount || '0');
-        const next = Math.max(0, current + delta);
-        button.dataset.tagCount = String(next);
-        const tag = availableTagsMap.get(String(tagId));
+        const value = Number(button.dataset.tagCount || '0');
+        return Number.isNaN(value) ? 0 : value;
+    }
+
+    function setFilterTagCount(tagId, value) {
+        if (!filterContainer) {
+            return 0;
+        }
+        const key = String(tagId);
+        const normalized = Math.max(0, Number(value) || 0);
+        const button = filterContainer.querySelector(`.tag-filter-button[data-tag-id="${key}"]`);
+        if (button) {
+            button.dataset.tagCount = String(normalized);
+        }
+        const tag = availableTagsMap.get(key);
         if (tag) {
-            tag.task_count = next;
+            tag.task_count = normalized;
         }
+        return normalized;
+    }
+
+    function adjustFilterTagCount(tagId, delta) {
+        const current = getFilterTagCount(tagId);
+        const next = current + Number(delta || 0);
+        return setFilterTagCount(tagId, next);
     }
 
     function updateTaskTagDisplay(taskId, tags) {
@@ -1397,18 +1477,18 @@
         if (!button) {
             return;
         }
+        const tagKey = String(tagId);
         const tagName = button.dataset.tagName || '';
-        const tagCount = Number(button.dataset.tagCount || '0');
-        const proceed = typeof showConfirmationModal === 'function'
+        const currentCount = setFilterTagCount(tagKey, getFilterTagCount(tagKey));
+        const shouldConfirm = currentCount > 0 && typeof showConfirmationModal === 'function';
+        const proceed = shouldConfirm
             ? showConfirmationModal({
                   title: 'Delete tag',
                   message: `Delete tag "#${tagName}"?`,
                   description: `Deleting this tag will remove "#${tagName}" from every associated task.`,
                   details: [
                       `Tag: #${tagName}`,
-                      tagCount > 0
-                          ? `${tagCount} task${tagCount === 1 ? '' : 's'} currently use this tag.`
-                          : 'This tag is not assigned to any tasks.',
+                      `${currentCount} task${currentCount === 1 ? '' : 's'} currently use this tag.`,
                       'This action cannot be undone.',
                   ],
                   confirmLabel: 'Delete tag',
@@ -1435,9 +1515,9 @@
                 })
                 .then(() => {
                     button.remove();
-                    availableTagsMap.delete(String(tagId));
+                    availableTagsMap.delete(tagKey);
                     updateFilterEmptyState();
-                    inlineSelectedTags.delete(String(tagId));
+                    inlineSelectedTags.delete(tagKey);
                     syncInlineTagsField();
                     renderInlineTagOptions();
                     applyTagFilters();
@@ -1814,7 +1894,11 @@
                 if (newContainer && currentContainer) {
                     currentContainer.replaceWith(newContainer);
                 }
-                hydrateAvailableTagsFromFilter();
+                if (Array.isArray(data.available_tags)) {
+                    syncFilterTags(data.available_tags);
+                } else {
+                    hydrateAvailableTagsFromFilter();
+                }
                 renderInlineTagOptions();
                 initializeSortableGroups();
                 attachTaskCompleteListeners();


### PR DESCRIPTION
## Summary
- return tag metadata with async task list responses so the UI knows current usage counts
- keep the client-side tag filter metadata in sync as tags are created, assigned, or removed
- only prompt for confirmation when deleting tags that are still in use and refresh tag counts before prompting

## Testing
- python -m compileall app.py models templates

------
https://chatgpt.com/codex/tasks/task_b_68e2156a5a848330a093b35c9d49e491