### PR TITLE
Add clipboard export actions for tasks and scopes

### DIFF
--- a/app.py
+++ b/app.py
@@ -306,6 +306,36 @@ def _user_owns_scope(scope: Scope) -> bool:
     return g.user is not None and scope is not None and scope.owner_id == g.user.id
 
 
+def _serialize_task_for_clipboard(task: Task) -> dict:
+    if task is None:
+        return {}
+
+    def _serialize_subtask(subtask: Task) -> dict:
+        if subtask is None:
+            return {}
+        return {
+            "id": subtask.id,
+            "name": subtask.name or "",
+            "description": subtask.description or "",
+        }
+
+    subtasks = sorted(
+        (subtask for subtask in task.subtasks or []),
+        key=lambda item: ((item.rank or 0), item.id),
+    )
+
+    return {
+        "id": task.id,
+        "name": task.name or "",
+        "description": task.description or "",
+        "due_date": task.end_date.isoformat() if task.end_date else None,
+        "completed": bool(task.completed),
+        "completed_date": task.completed_date.isoformat() if task.completed_date else None,
+        "tags": [tag.name for tag in task.tags],
+        "subtasks": [_serialize_subtask(subtask) for subtask in subtasks],
+    }
+
+
 @app.route("/scope/<int:id>")
 def set_scope(id):
     scope = Scope.query.get_or_404(id)
@@ -324,6 +354,41 @@ def scope():
     session.pop("selected_scope", None)
     g.scope = None
     return render_template("scope.html", scopes=items, scope_form=form)
+
+
+@app.route("/scope/<int:id>/tasks/export", methods=["GET"])
+def export_scope_tasks(id):
+    scope = Scope.query.get_or_404(id)
+    if not _user_can_access_scope(scope):
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "message": "You do not have permission to export tasks for this scope.",
+                }
+            ),
+            403,
+        )
+
+    if g.user is None:
+        return (
+            jsonify({"success": False, "message": "You must be logged in to export tasks."}),
+            401,
+        )
+
+    user_tasks = [task for task in scope.tasks if task.owner_id == g.user.id]
+    user_tasks.sort(key=lambda item: ((item.rank or 0), item.id))
+
+    payload = [_serialize_task_for_clipboard(task) for task in user_tasks]
+
+    return jsonify(
+        {
+            "success": True,
+            "scope": {"id": scope.id, "name": scope.name or ""},
+            "tasks": payload,
+        }
+    )
+
 
 @app.route("/task")
 @scope_required

--- a/templates/components/task_groups.html
+++ b/templates/components/task_groups.html
@@ -9,22 +9,42 @@
                 {% set show_quick_add = (sort_by == 'tags' and group.tag_id is defined) or (sort_by == 'due_date' and group.due_bucket is defined) %}
                 <div class="task-group-header">
                     <h6 class="task-group-title text-uppercase text-muted small mb-0">{{ group.title }}</h6>
-                    {% if show_quick_add %}
+                    <div class="task-group-action-buttons">
                         <button type="button"
-                                class="btn btn-outline-primary btn-sm task-group-add-btn"
-                                {% if group.tag_id is defined %}data-group-tag-id="{{ group.tag_id if group.tag_id is not none else '' }}"{% endif %}
-                                {% if group.due_bucket is defined %}data-group-due-bucket="{{ group.due_bucket }}"{% endif %}
-                                aria-label="Quick add task for {{ group.title }}">
-                            <i class="bi bi-plus-lg"></i>
+                                class="btn btn-outline-secondary btn-sm task-group-copy-btn"
+                                aria-label="Copy tasks for {{ group.title }}">
+                            <i class="bi bi-clipboard"></i>
                         </button>
-                    {% endif %}
+                        {% if show_quick_add %}
+                            <button type="button"
+                                    class="btn btn-outline-primary btn-sm task-group-add-btn"
+                                    {% if group.tag_id is defined %}data-group-tag-id="{{ group.tag_id if group.tag_id is not none else '' }}"{% endif %}
+                                    {% if group.due_bucket is defined %}data-group-due-bucket="{{ group.due_bucket }}"{% endif %}
+                                    aria-label="Quick add task for {{ group.title }}">
+                                <i class="bi bi-plus-lg"></i>
+                            </button>
+                        {% endif %}
+                    </div>
                 </div>
             {% endif %}
             <div class="accordion" id="{{ group.dom_id }}" data-sortable="{{ 'true' if group.sortable else 'false' }}">
                 {% if group.tasks %}
                     {% for task in group.tasks %}
                         {% set has_details = task.has_info() or task.completed_date %}
-                        <div class="m-1 px-2 sketchy-border task-item" data-task-id="{{ task.id }}" data-tag-ids="{{ task.tags | map(attribute='id') | join(',') }}">
+                        {% set subtask_ns = namespace(items=[]) %}
+                        {% for subtask in task.subtasks %}
+                            {% set _ = subtask_ns.items.append({'name': subtask.name, 'description': subtask.description}) %}
+                        {% endfor %}
+                        <div class="m-1 px-2 sketchy-border task-item"
+                             data-task-id="{{ task.id }}"
+                             data-tag-ids="{{ task.tags | map(attribute='id') | join(',') }}"
+                             data-task-name="{{ task.name | e }}"
+                             data-task-description="{{ task.description | default('') | e }}"
+                             data-task-due-date="{{ task.end_date.isoformat() if task.end_date else '' }}"
+                             data-task-completed="{{ 'true' if task.completed else 'false' }}"
+                             data-task-completed-date="{{ task.completed_date.isoformat() if task.completed_date else '' }}"
+                             data-task-tags='{{ task.tags | map(attribute="name") | list | tojson | e }}'
+                             data-task-subtasks='{{ subtask_ns.items | tojson | e }}'>
                             <div class="task-item-header my-1" id="heading{{ group.dom_id }}-{{ task.id }}">
                                 <div class="d-flex align-items-center flex-grow-1">
                                     <i class="bi bi-grip-vertical text-muted {{ '' if group.sortable else 'drag-disabled' }}" id="grip" data-item-id="{{ task.id }}"></i>
@@ -59,6 +79,9 @@
                                             <i class="bi bi-check"></i>
                                         {% endif %}
                                     </a>
+                                    <button type="button" class="btn task-action-btn task-copy-btn" aria-label="Copy task {{ task.name | e }}">
+                                        <i class="bi bi-clipboard"></i>
+                                    </button>
                                     <button type="button" class="btn task-action-btn tag-manager-btn" data-task-id="{{ task.id }}" data-task-name="{{ task.name | e }}">
                                         <i class="bi bi-tags"></i>
                                     </button>

--- a/templates/scope.html
+++ b/templates/scope.html
@@ -19,8 +19,15 @@
             <div class="card border-secondary" >
                 <div class="card-header d-flex justify-content-between align-items-top" {% if scope.owner_id == g.user.id %}id="grip" data-item-id="{{ scope.id }}"{% endif %}>
                     <i class="bi bi-grip-vertical text-muted {% if scope.owner_id != g.user.id %}opacity-50{% endif %}"></i>
+                    <div class="d-flex justify-content-between align-items-start">
+                        <button type="button"
+                            class="btn btn-link p-0 text-muted scope-copy-btn clickable-icon mx-1"
+                            data-scope-id="{{ scope.id }}"
+                            data-scope-name="{{ scope.name | e }}"
+                            aria-label="Copy tasks for scope {{ scope.name }}">
+                            <i class="bi bi-clipboard"></i>
+                        </button>
                     {% if scope.owner_id == g.user.id %}
-                    <div class="d-flex justify-content-between">
                         <button type="button"
                             class="btn btn-link p-0 text-muted edit-scope-btn clickable-icon mx-1"
                             data-bs-toggle="modal"
@@ -38,10 +45,8 @@
                             aria-label="Delete scope {{ scope.name }}">
                             <i class="bi bi-trash3"></i>
                         </button>
-                    </div>
-                    {% else %}
-                    <div class="d-flex"></div>
                     {% endif %}
+                    </div>
                 </div>
                 <a class="text-decoration-none no-visited" href="{{url_for('set_scope',id=scope.id)}}">
                     <div class="card-body text-center">{{scope.name}}</div>
@@ -63,6 +68,183 @@
     {{ super() }}
 <script>
     initializeSortable('scopes-list', 'scope');
+
+    function formatDateTimeDisplay(utcDateString) {
+        if (!utcDateString) {
+            return '';
+        }
+        const normalized = utcDateString.endsWith('Z') ? utcDateString : `${utcDateString}Z`;
+        const date = new Date(normalized);
+        if (Number.isNaN(date.getTime())) {
+            return '';
+        }
+        return date.toLocaleString(undefined, {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+            hour: 'numeric',
+            minute: 'numeric',
+        });
+    }
+
+    function decodeHtmlEntities(text) {
+        if (typeof text !== 'string' || !text) {
+            return '';
+        }
+        const textarea = document.createElement('textarea');
+        textarea.innerHTML = text;
+        return textarea.value;
+    }
+
+    function copyTextToClipboard(text) {
+        if (typeof text !== 'string' || !text.trim()) {
+            return Promise.reject(new Error('Nothing to copy'));
+        }
+        if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+            return navigator.clipboard.writeText(text.trim());
+        }
+
+        return new Promise((resolve, reject) => {
+            try {
+                const textarea = document.createElement('textarea');
+                textarea.value = text.trim();
+                textarea.setAttribute('readonly', '');
+                textarea.style.position = 'absolute';
+                textarea.style.left = '-9999px';
+                document.body.appendChild(textarea);
+                textarea.select();
+                const successful = document.execCommand('copy');
+                document.body.removeChild(textarea);
+                if (successful) {
+                    resolve();
+                } else {
+                    reject(new Error('Copy command was unsuccessful'));
+                }
+            } catch (error) {
+                reject(error);
+            }
+        });
+    }
+
+    function formatTaskClipboardText(task) {
+        if (!task) {
+            return '';
+        }
+        const lines = [];
+        const title = task.name ? `Task: ${task.name}` : 'Task';
+        lines.push(title);
+
+        if (task.description) {
+            lines.push('Description:');
+            lines.push(task.description);
+        }
+
+        if (task.due_date) {
+            const formattedDue = formatDateTimeDisplay(task.due_date) || task.due_date;
+            lines.push(`Due: ${formattedDue}`);
+        }
+
+        if (task.completed) {
+            const completion = formatDateTimeDisplay(task.completed_date) || task.completed_date;
+            lines.push(completion ? `Status: Completed (${completion})` : 'Status: Completed');
+        } else {
+            lines.push('Status: In progress');
+        }
+
+        if (Array.isArray(task.tags) && task.tags.length > 0) {
+            const formattedTags = task.tags
+                .map((tag) => (typeof tag === 'string' && tag.trim() ? `#${tag.trim()}` : null))
+                .filter(Boolean)
+                .join(', ');
+            if (formattedTags) {
+                lines.push(`Tags: ${formattedTags}`);
+            }
+        }
+
+        if (Array.isArray(task.subtasks) && task.subtasks.length > 0) {
+            lines.push('Subtasks:');
+            task.subtasks.forEach((subtask) => {
+                if (!subtask || typeof subtask !== 'object') {
+                    return;
+                }
+                const name = (subtask.name || '').trim();
+                const description = (subtask.description || '').trim();
+                const detail = description ? `${name} — ${description}` : name;
+                lines.push(`- ${detail || 'Untitled subtask'}`);
+            });
+        }
+
+        return lines.join('\n').trim();
+    }
+
+    function copyScopeTasks(scopeId, scopeName) {
+        if (!scopeId) {
+            return Promise.reject(new Error('Missing scope identifier'));
+        }
+        return fetch(`/scope/${scopeId}/tasks/export`, {
+            headers: {
+                'X-Requested-With': 'XMLHttpRequest',
+                Accept: 'application/json',
+            },
+        })
+            .then((response) => {
+                if (!response.ok) {
+                    return response
+                        .json()
+                        .catch(() => ({}))
+                        .then((data) => Promise.reject(data));
+                }
+                return response.json();
+            })
+            .then((data) => {
+                if (!data || data.success !== true || !Array.isArray(data.tasks)) {
+                    return Promise.reject(data || new Error('Invalid response'));
+                }
+                if (data.tasks.length === 0) {
+                    displayFlashMessage(`There are no tasks to copy for "${scopeName || 'this scope'}".`, 'info');
+                    return null;
+                }
+                const clipboardSections = data.tasks
+                    .map((task, index) => {
+                        const formatted = formatTaskClipboardText(task);
+                        return formatted ? `${index + 1}. ${formatted}` : null;
+                    })
+                    .filter(Boolean);
+
+                if (clipboardSections.length === 0) {
+                    return Promise.reject(new Error('No tasks could be formatted'));
+                }
+
+                const header = scopeName ? `${scopeName}\n` : '';
+                const clipboardText = `${header}${clipboardSections.join('\n\n')}`;
+                return copyTextToClipboard(clipboardText).then(() => clipboardSections.length);
+            });
+    }
+
+    document.querySelectorAll('.scope-copy-btn').forEach((button) => {
+        button.addEventListener('click', (event) => {
+            event.preventDefault();
+            const scopeId = button.dataset.scopeId;
+            const scopeName = decodeHtmlEntities(button.dataset.scopeName || '');
+            copyScopeTasks(scopeId, scopeName)
+                .then((count) => {
+                    if (typeof count !== 'number') {
+                        return;
+                    }
+                    displayFlashMessage(
+                        `Copied ${count} task${count === 1 ? '' : 's'} from "${scopeName || 'this scope'}" to the clipboard.`,
+                        'success'
+                    );
+                })
+                .catch((error) => {
+                    if (error && error.message) {
+                        console.error('Unable to copy scope tasks', error);
+                    }
+                    const message = (error && error.message) || 'Unable to copy tasks for this scope.';
+                    displayFlashMessage(message, 'danger');
+                });
+        });
+    });
 
     document.querySelectorAll('.scope-delete-btn').forEach((button) => {
         button.addEventListener('click', (event) => {

--- a/templates/task.html
+++ b/templates/task.html
@@ -58,6 +58,12 @@
         margin-bottom: 0;
     }
 
+    .task-group-action-buttons {
+        display: inline-flex;
+        gap: 0.25rem;
+        margin-left: auto;
+    }
+
     .task-item-header {
         display: flex;
         flex-wrap: wrap;
@@ -642,6 +648,150 @@
         });
     }
 
+    function decodeHtmlEntities(text) {
+        if (typeof text !== 'string' || !text) {
+            return '';
+        }
+        const textarea = document.createElement('textarea');
+        textarea.innerHTML = text;
+        return textarea.value;
+    }
+
+    function parseJsonAttribute(value, fallback) {
+        if (typeof value !== 'string' || !value.trim()) {
+            return fallback;
+        }
+        try {
+            return JSON.parse(value);
+        } catch (error) {
+            console.warn('Unable to parse JSON attribute', value, error);
+            return fallback;
+        }
+    }
+
+    function normalizeMultiline(text) {
+        if (typeof text !== 'string') {
+            return '';
+        }
+        return text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+    }
+
+    function buildTaskClipboardDataFromElement(taskElement) {
+        if (!(taskElement instanceof HTMLElement)) {
+            return null;
+        }
+        const dataset = taskElement.dataset || {};
+        const name = decodeHtmlEntities(dataset.taskName || '');
+        const description = decodeHtmlEntities(dataset.taskDescription || '');
+        const dueDate = dataset.taskDueDate || '';
+        const completed = dataset.taskCompleted === 'true';
+        const completedDate = dataset.taskCompletedDate || '';
+        const tags = parseJsonAttribute(dataset.taskTags, []);
+        const subtasks = parseJsonAttribute(dataset.taskSubtasks, []);
+
+        return {
+            id: dataset.taskId || '',
+            name,
+            description: normalizeMultiline(description),
+            dueDate,
+            completed,
+            completedDate,
+            tags: Array.isArray(tags) ? tags : [],
+            subtasks: Array.isArray(subtasks) ? subtasks : [],
+        };
+    }
+
+    function formatTaskClipboardText(taskData) {
+        if (!taskData) {
+            return '';
+        }
+        const lines = [];
+        const title = taskData.name ? `Task: ${taskData.name}` : 'Task';
+        lines.push(title);
+
+        if (taskData.description) {
+            lines.push('Description:');
+            lines.push(taskData.description);
+        }
+
+        if (taskData.dueDate) {
+            const formattedDue = typeof formatDateTimeDisplay === 'function'
+                ? formatDateTimeDisplay(taskData.dueDate)
+                : taskData.dueDate;
+            if (formattedDue) {
+                lines.push(`Due: ${formattedDue}`);
+            }
+        }
+
+        if (taskData.completed) {
+            const completion = taskData.completedDate && typeof formatDateTimeDisplay === 'function'
+                ? formatDateTimeDisplay(taskData.completedDate)
+                : taskData.completedDate;
+            lines.push(
+                completion
+                    ? `Status: Completed (${completion})`
+                    : 'Status: Completed'
+            );
+        } else {
+            lines.push('Status: In progress');
+        }
+
+        if (Array.isArray(taskData.tags) && taskData.tags.length > 0) {
+            const formattedTags = taskData.tags
+                .map((tag) => (typeof tag === 'string' && tag.trim() ? `#${tag.trim()}` : null))
+                .filter(Boolean)
+                .join(', ');
+            if (formattedTags) {
+                lines.push(`Tags: ${formattedTags}`);
+            }
+        }
+
+        if (Array.isArray(taskData.subtasks) && taskData.subtasks.length > 0) {
+            lines.push('Subtasks:');
+            taskData.subtasks.forEach((subtask) => {
+                if (!subtask || typeof subtask !== 'object') {
+                    return;
+                }
+                const name = decodeHtmlEntities(subtask.name || '').trim();
+                const description = decodeHtmlEntities(subtask.description || '').trim();
+                const detail = description ? `${name} — ${description}` : name;
+                lines.push(`- ${detail || 'Untitled subtask'}`);
+            });
+        }
+
+        return lines.join('\n').trim();
+    }
+
+    function copyTextToClipboard(text) {
+        if (typeof text !== 'string' || !text.trim()) {
+            return Promise.reject(new Error('Nothing to copy'));
+        }
+        if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+            return navigator.clipboard.writeText(text.trim());
+        }
+
+        return new Promise((resolve, reject) => {
+            try {
+                const textarea = document.createElement('textarea');
+                textarea.value = text.trim();
+                textarea.setAttribute('readonly', '');
+                textarea.style.position = 'absolute';
+                textarea.style.left = '-9999px';
+                document.body.appendChild(textarea);
+                textarea.select();
+                const successful = document.execCommand('copy');
+                document.body.removeChild(textarea);
+                if (successful) {
+                    resolve();
+                } else {
+                    reject(new Error('Copy command was unsuccessful'));
+                }
+            } catch (error) {
+                reject(error);
+            }
+        });
+    }
+
     function formatDateInputValue(date) {
         if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
             return '';
@@ -963,6 +1113,90 @@
                     tagIdValue: typeof trigger.dataset.groupTagId === 'string' ? trigger.dataset.groupTagId : null,
                     dueBucket: typeof trigger.dataset.groupDueBucket === 'string' ? trigger.dataset.groupDueBucket : null,
                 });
+            });
+        });
+    }
+
+    const taskCopyListenerAttached = new WeakSet();
+    function attachTaskCopyListeners() {
+        document.querySelectorAll('.task-copy-btn').forEach((button) => {
+            if (taskCopyListenerAttached.has(button)) {
+                return;
+            }
+            taskCopyListenerAttached.add(button);
+            button.addEventListener('click', (event) => {
+                event.preventDefault();
+                const trigger = event.currentTarget;
+                const taskElement = trigger.closest('.task-item');
+                const taskData = buildTaskClipboardDataFromElement(taskElement);
+                const taskName = taskData && taskData.name ? taskData.name : 'Task';
+                if (!taskData) {
+                    displayFlashMessage('Unable to copy this task.', 'danger');
+                    return;
+                }
+                const clipboardText = formatTaskClipboardText(taskData);
+                copyTextToClipboard(clipboardText)
+                    .then(() => {
+                        displayFlashMessage(`Task "${taskName}" copied to clipboard.`, 'success');
+                    })
+                    .catch((error) => {
+                        console.error('Unable to copy task', error);
+                        displayFlashMessage('Unable to copy this task to the clipboard.', 'danger');
+                    });
+            });
+        });
+    }
+
+    const groupCopyListenerAttached = new WeakSet();
+    function attachGroupCopyListeners() {
+        document.querySelectorAll('.task-group-copy-btn').forEach((button) => {
+            if (groupCopyListenerAttached.has(button)) {
+                return;
+            }
+            groupCopyListenerAttached.add(button);
+            button.addEventListener('click', (event) => {
+                event.preventDefault();
+                const groupElement = button.closest('.task-group');
+                if (!groupElement) {
+                    displayFlashMessage('Unable to locate this task group.', 'danger');
+                    return;
+                }
+                const taskElements = Array.from(groupElement.querySelectorAll('.task-item'));
+                if (taskElements.length === 0) {
+                    displayFlashMessage('There are no tasks to copy in this group.', 'info');
+                    return;
+                }
+                const clipboardSections = taskElements
+                    .map((taskElement) => buildTaskClipboardDataFromElement(taskElement))
+                    .filter(Boolean)
+                    .map((taskData, index) => {
+                        const formatted = formatTaskClipboardText(taskData);
+                        return formatted ? `${index + 1}. ${formatted}` : null;
+                    })
+                    .filter(Boolean);
+
+                if (clipboardSections.length === 0) {
+                    displayFlashMessage('Unable to copy the selected tasks.', 'danger');
+                    return;
+                }
+
+                const titleElement = groupElement.querySelector('.task-group-title');
+                const groupTitle = titleElement ? titleElement.textContent.trim() : '';
+                const header = groupTitle ? `${groupTitle}\n` : '';
+                const clipboardText = `${header}${clipboardSections.join('\n\n')}`;
+                copyTextToClipboard(clipboardText)
+                    .then(() => {
+                        const count = clipboardSections.length;
+                        const label = groupTitle || 'group';
+                        displayFlashMessage(
+                            `Copied ${count} task${count === 1 ? '' : 's'} from "${label}" to the clipboard.`,
+                            'success'
+                        );
+                    })
+                    .catch((error) => {
+                        console.error('Unable to copy tasks from group', error);
+                        displayFlashMessage('Unable to copy tasks from this group.', 'danger');
+                    });
             });
         });
     }
@@ -1821,6 +2055,8 @@
                 attachEditTaskListeners();
                 attachTagManagerListeners();
                 attachTaskDeleteListeners();
+                attachTaskCopyListeners();
+                attachGroupCopyListeners();
                 attachGroupAddListeners();
                 syncChevronStates();
                 updateDateDisplays();
@@ -1838,6 +2074,8 @@
     attachEditTaskListeners();
     attachTagManagerListeners();
     attachTaskDeleteListeners();
+    attachTaskCopyListeners();
+    attachGroupCopyListeners();
     attachGroupAddListeners();
     applyTagFilters();
     updateDateDisplays();


### PR DESCRIPTION
## Summary
- add clipboard copy buttons for individual tasks, task groups, and scopes
- serialize task details for clipboard export via a new scope export endpoint
- implement client-side formatting and clipboard helpers to deliver readable task summaries

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_b_68e222215ee4833099f9063339648372