### PR TITLE
Persist task filter preferences and last scope selection

### DIFF
--- a/templates/components/task_groups.html
+++ b/templates/components/task_groups.html
@@ -1,4 +1,4 @@
-<div class="container mt-2" id="task-groups-container" data-sort-by="{{ sort_by }}" data-sortable-groups='{{ sortable_group_ids | tojson | e }}' data-has-github-linked="{{ 'true' if has_github_linked_tasks else 'false' }}">
+<div class="container mt-2" id="task-groups-container" data-sort-by="{{ sort_by }}" data-sortable-groups='{{ sortable_group_ids | tojson | e }}' data-has-github-linked="{{ 'true' if has_github_linked_tasks else 'false' }}" data-scope-id="{{ g.scope.id if g.scope else '' }}">
     {% set ns = namespace(has_tasks=false) %}
     {% for group in task_groups %}
         {% if group.tasks %}

--- a/templates/scope.html
+++ b/templates/scope.html
@@ -16,7 +16,7 @@
     <div class="row g-3 justify-content-center" id="scopes-list">
     {% for scope in scopes %}
         <div class="col">
-            <div class="card border-secondary" >
+            <div class="card border-secondary" data-scope-id="{{ scope.id }}" data-scope-url="{{ url_for('set_scope', id=scope.id) }}">
                 <div class="card-header d-flex justify-content-between align-items-top" {% if scope.owner_id == g.user.id %}id="grip" data-item-id="{{ scope.id }}"{% endif %}>
                     <i class="bi bi-grip-vertical text-muted {% if scope.owner_id != g.user.id %}opacity-50{% endif %}"></i>
                     <div class="d-flex justify-content-between align-items-start">
@@ -48,7 +48,7 @@
                     {% endif %}
                     </div>
                 </div>
-                <a class="text-decoration-none no-visited" href="{{url_for('set_scope',id=scope.id)}}">
+                <a class="text-decoration-none no-visited" href="{{url_for('set_scope',id=scope.id)}}" data-scope-id="{{ scope.id }}">
                     <div class="card-body text-center">{{scope.name}}</div>
                 </a>
             </div>
@@ -68,6 +68,128 @@
     {{ super() }}
 <script>
     initializeSortable('scopes-list', 'scope');
+
+    const PREFERENCE_STORAGE_KEY = 'pm:preferences';
+
+    function readPreferenceData() {
+        const fallback = { lastScopeId: null, scopes: {} };
+        if (typeof window === 'undefined' || !('localStorage' in window)) {
+            return { ...fallback };
+        }
+        try {
+            const raw = window.localStorage.getItem(PREFERENCE_STORAGE_KEY);
+            if (!raw) {
+                return { ...fallback };
+            }
+            const parsed = JSON.parse(raw);
+            const scopes = parsed && typeof parsed.scopes === 'object' && parsed.scopes !== null ? parsed.scopes : {};
+            const lastScopeId = parsed && parsed.lastScopeId != null ? String(parsed.lastScopeId) : null;
+            return { lastScopeId, scopes };
+        } catch (error) {
+            console.warn('Unable to read scope preferences from localStorage.', error);
+            return { ...fallback };
+        }
+    }
+
+    function writePreferenceData(data) {
+        if (typeof window === 'undefined' || !('localStorage' in window)) {
+            return;
+        }
+        try {
+            window.localStorage.setItem(PREFERENCE_STORAGE_KEY, JSON.stringify(data));
+        } catch (error) {
+            console.warn('Unable to persist scope preferences to localStorage.', error);
+        }
+    }
+
+    function updatePreferenceData(updater) {
+        const current = readPreferenceData();
+        const draft = {
+            lastScopeId: current.lastScopeId,
+            scopes: { ...current.scopes },
+        };
+        const result = typeof updater === 'function' ? updater(draft) || draft : draft;
+        const normalized = {
+            lastScopeId: result.lastScopeId != null ? String(result.lastScopeId) : null,
+            scopes: result.scopes && typeof result.scopes === 'object' ? result.scopes : {},
+        };
+        writePreferenceData(normalized);
+        return normalized;
+    }
+
+    function setLastScopePreference(scopeId) {
+        updatePreferenceData((data) => {
+            data.lastScopeId = scopeId != null ? String(scopeId) : null;
+            return data;
+        });
+    }
+
+    function getLastScopePreference() {
+        const data = readPreferenceData();
+        return data.lastScopeId != null ? String(data.lastScopeId) : null;
+    }
+
+    function shouldAutoNavigateToScope() {
+        if (typeof window === 'undefined') {
+            return false;
+        }
+        const params = new URLSearchParams(window.location.search);
+        if (params.get('stay') === '1' || params.get('stay') === 'true') {
+            return false;
+        }
+        const referrer = document.referrer || '';
+        if (!referrer) {
+            return true;
+        }
+        try {
+            const refUrl = new URL(referrer, window.location.origin);
+            if (refUrl.origin !== window.location.origin) {
+                return false;
+            }
+            const allowedPaths = new Set(['', '/', '/login', '/signup']);
+            return allowedPaths.has(refUrl.pathname);
+        } catch (error) {
+            console.warn('Unable to evaluate referrer for auto scope selection.', error);
+            return false;
+        }
+    }
+
+    function attemptStoredScopeRedirect() {
+        const scopeCards = Array.from(document.querySelectorAll('.card[data-scope-id][data-scope-url]'));
+        if (scopeCards.length === 0) {
+            setLastScopePreference(null);
+            return;
+        }
+        const storedScopeId = getLastScopePreference();
+        let targetCard = null;
+        if (storedScopeId) {
+            targetCard = scopeCards.find((card) => card.dataset.scopeId === storedScopeId) || null;
+        }
+        if (!targetCard) {
+            targetCard = scopeCards[0];
+        }
+        if (!targetCard) {
+            setLastScopePreference(null);
+            return;
+        }
+        const targetScopeId = targetCard.dataset.scopeId || null;
+        const targetScopeUrl = targetCard.dataset.scopeUrl || '';
+        setLastScopePreference(targetScopeId);
+        if (!targetScopeUrl || !shouldAutoNavigateToScope()) {
+            return;
+        }
+        window.setTimeout(() => {
+            window.location.href = targetScopeUrl;
+        }, 150);
+    }
+
+    attemptStoredScopeRedirect();
+
+    document.querySelectorAll('a[data-scope-id]').forEach((link) => {
+        link.addEventListener('click', () => {
+            setLastScopePreference(link.dataset.scopeId);
+        });
+    });
 
     function formatDateTimeDisplay(utcDateString) {
         if (!utcDateString) {

--- a/templates/task.html
+++ b/templates/task.html
@@ -555,6 +555,185 @@
     const filterCollapse = filterCollapseElement ? new bootstrap.Collapse(filterCollapseElement, { toggle: false }) : null;
     const filterMediaQuery = window.matchMedia('(min-width: 992px)');
 
+    const PREFERENCE_STORAGE_KEY = 'pm:preferences';
+    const ACTIVE_SCOPE_ID = {{ g.scope.id | tojson if g.scope else 'null' }};
+
+    function readPreferenceData() {
+        const fallback = { lastScopeId: null, scopes: {} };
+        if (typeof window === 'undefined' || !('localStorage' in window)) {
+            return { ...fallback };
+        }
+        try {
+            const raw = window.localStorage.getItem(PREFERENCE_STORAGE_KEY);
+            if (!raw) {
+                return { ...fallback };
+            }
+            const parsed = JSON.parse(raw);
+            const scopes = parsed && typeof parsed.scopes === 'object' && parsed.scopes !== null ? parsed.scopes : {};
+            const lastScopeId = parsed && parsed.lastScopeId != null ? String(parsed.lastScopeId) : null;
+            return { lastScopeId, scopes };
+        } catch (error) {
+            console.warn('Unable to read task preferences from localStorage.', error);
+            return { ...fallback };
+        }
+    }
+
+    function writePreferenceData(data) {
+        if (typeof window === 'undefined' || !('localStorage' in window)) {
+            return;
+        }
+        try {
+            window.localStorage.setItem(PREFERENCE_STORAGE_KEY, JSON.stringify(data));
+        } catch (error) {
+            console.warn('Unable to persist task preferences to localStorage.', error);
+        }
+    }
+
+    function updatePreferenceData(updater) {
+        const current = readPreferenceData();
+        const draft = {
+            lastScopeId: current.lastScopeId,
+            scopes: { ...current.scopes },
+        };
+        const result = typeof updater === 'function' ? updater(draft) || draft : draft;
+        const normalized = {
+            lastScopeId: result.lastScopeId != null ? String(result.lastScopeId) : null,
+            scopes: result.scopes && typeof result.scopes === 'object' ? result.scopes : {},
+        };
+        writePreferenceData(normalized);
+        return normalized;
+    }
+
+    function getStoredScopePreferences(scopeId) {
+        if (scopeId == null) {
+            return null;
+        }
+        const data = readPreferenceData();
+        const scopeKey = String(scopeId);
+        const stored = data.scopes && typeof data.scopes === 'object' ? data.scopes[scopeKey] : null;
+        if (!stored || typeof stored !== 'object') {
+            return null;
+        }
+        return {
+            search: typeof stored.search === 'string' ? stored.search : '',
+            sortBy: typeof stored.sortBy === 'string' ? stored.sortBy : '',
+            showCompleted: Boolean(stored.showCompleted),
+            tags: Array.isArray(stored.tags) ? stored.tags.map((value) => String(value)) : [],
+        };
+    }
+
+    function getCurrentScopeId() {
+        const container = getTaskGroupsContainer();
+        if (container) {
+            const { scopeId } = container.dataset;
+            if (scopeId && scopeId !== 'null' && scopeId !== 'undefined') {
+                return scopeId;
+            }
+        }
+        if (ACTIVE_SCOPE_ID !== null && ACTIVE_SCOPE_ID !== undefined) {
+            return String(ACTIVE_SCOPE_ID);
+        }
+        return null;
+    }
+
+    function persistTaskPreferences() {
+        const scopeId = getCurrentScopeId();
+        if (!scopeId) {
+            updatePreferenceData((data) => {
+                data.lastScopeId = null;
+                return data;
+            });
+            return;
+        }
+        const scopeKey = String(scopeId);
+        const searchValue = searchInput ? (searchInput.value || '').trim() : '';
+        const sortValue = sortSelect ? (sortSelect.value || '').trim() : '';
+        const showCompletedValue = Boolean(filterCompleted && filterCompleted.checked);
+        const activeTags = filterContainer
+            ? Array.from(filterContainer.querySelectorAll('.tag-filter-button.active'))
+                  .map((button) => String(button.dataset.tagId))
+                  .filter((value) => value)
+            : [];
+        updatePreferenceData((data) => {
+            data.lastScopeId = scopeKey;
+            const existing = data.scopes[scopeKey];
+            data.scopes[scopeKey] = {
+                ...(existing && typeof existing === 'object' ? existing : {}),
+                search: searchValue,
+                sortBy: sortValue,
+                showCompleted: showCompletedValue,
+                tags: activeTags,
+            };
+            return data;
+        });
+    }
+
+    function restoreTaskPreferences() {
+        const scopeId = getCurrentScopeId();
+        updatePreferenceData((data) => {
+            data.lastScopeId = scopeId != null ? String(scopeId) : null;
+            return data;
+        });
+        if (!scopeId) {
+            return;
+        }
+        const stored = getStoredScopePreferences(scopeId);
+        if (!stored) {
+            persistTaskPreferences();
+            return;
+        }
+        let shouldRefresh = false;
+        if (searchInput && typeof stored.search === 'string') {
+            const trimmed = stored.search;
+            if (searchInput.value !== trimmed) {
+                searchInput.value = trimmed;
+                shouldRefresh = true;
+            }
+        }
+        if (filterCompleted) {
+            const desired = Boolean(stored.showCompleted);
+            if (filterCompleted.checked !== desired) {
+                filterCompleted.checked = desired;
+                shouldRefresh = true;
+            }
+        }
+        if (sortSelect && typeof stored.sortBy === 'string' && stored.sortBy) {
+            const availableOptions = Array.from(sortSelect.options || []);
+            if (availableOptions.some((option) => option.value === stored.sortBy) && sortSelect.value !== stored.sortBy) {
+                sortSelect.value = stored.sortBy;
+                shouldRefresh = true;
+            }
+        }
+
+        let tagsChanged = false;
+        let desiredTagCount = 0;
+        if (filterContainer && Array.isArray(stored.tags)) {
+            const desiredTags = stored.tags.map((value) => String(value)).filter((value) => value);
+            desiredTagCount = desiredTags.length;
+            const desiredSet = new Set(desiredTags);
+            const buttons = Array.from(filterContainer.querySelectorAll('.tag-filter-button'));
+            buttons.forEach((button) => {
+                const tagId = button.dataset.tagId;
+                const shouldBeActive = desiredSet.has(tagId);
+                if (button.classList.contains('active') !== shouldBeActive) {
+                    button.classList.toggle('active', shouldBeActive);
+                    tagsChanged = true;
+                }
+            });
+            if (tagsChanged || desiredTagCount > 0) {
+                applyTagFilters();
+            }
+        }
+
+        const refreshPromise = shouldRefresh ? refreshTaskList() : Promise.resolve();
+        refreshPromise.finally(() => {
+            if (!tagsChanged && desiredTagCount === 0) {
+                applyTagFilters();
+            }
+            persistTaskPreferences();
+        });
+    }
+
     if (detailedItemContainer && quickToggleIcon) {
         const setQuickToggleIcon = (isExpanded) => {
             quickToggleIcon.classList.toggle('bi-chevron-down', !isExpanded);
@@ -1533,6 +1712,7 @@
         if (showMessage && typeof displayFlashMessage === 'function' && tagName) {
             displayFlashMessage(`Tag "#${tagName}" deleted.`, 'success');
         }
+        persistTaskPreferences();
     }
 
     function deleteTagFromServer(tagId, tagName = '', { onSuccess = null, onError = null, showError = true } = {}) {
@@ -1914,6 +2094,7 @@
         }
         button.classList.toggle('active');
         applyTagFilters();
+        persistTaskPreferences();
     }
 
     const handleFilterRemoveKeydown = (event) => {
@@ -1940,6 +2121,7 @@
                 button.classList.remove('active');
             });
             applyTagFilters();
+            persistTaskPreferences();
         });
     }
 
@@ -2644,6 +2826,7 @@
                 syncChevronStates();
                 updateDateDisplays();
                 applyTagFilters();
+                persistTaskPreferences();
             })
             .catch((error) => {
                 console.error('Unable to refresh tasks', error);
@@ -2664,6 +2847,8 @@
     applyTagFilters();
     updateDateDisplays();
     syncChevronStates();
+
+    restoreTaskPreferences();
 
     if (filterCollapseElement && filterCollapse) {
         const handleBreakpointChange = () => {
@@ -2795,24 +2980,28 @@
     if (filterForm) {
         filterForm.addEventListener('submit', (event) => {
             event.preventDefault();
+            persistTaskPreferences();
             refreshTaskList();
         });
     }
 
     if (sortSelect) {
         sortSelect.addEventListener('change', () => {
+            persistTaskPreferences();
             refreshTaskList();
         });
     }
 
     if (filterCompleted) {
         filterCompleted.addEventListener('change', () => {
+            persistTaskPreferences();
             refreshTaskList();
         });
     }
 
     if (searchInput) {
         const debouncedSearch = debounce(() => {
+            persistTaskPreferences();
             refreshTaskList();
         }, 300);
         searchInput.addEventListener('input', () => {


### PR DESCRIPTION
## Summary
- store per-scope task filters (search text, completion toggle, sort order, tags) in local storage and restore them on load
- remember the last selected scope in local storage and auto-navigate to it when returning to the app
- expose the active scope id on the task list container to support preference persistence

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e5aeec4c00833099afe042c4271ab4