### PR TITLE
Fixes Task Details Expansion for Linked GitHub Tasks

### DIFF
--- a/templates/task.html
+++ b/templates/task.html
@@ -1462,6 +1462,7 @@
         }
 
         event.preventDefault();
+        const collapseId = collapseElement.id;
 
         (async () => {
             try {
@@ -1497,8 +1498,11 @@
                 if (typeof refreshTaskList === 'function') {
                     try {
                         await refreshTaskList();
-                        const nextTaskElement = document.querySelector(`.task-item[data-task-id="${taskId}"]`);
-                        const nextCollapse = nextTaskElement ? nextTaskElement.querySelector('.accordion-collapse') : null;
+                        let nextCollapse = collapseId ? document.getElementById(collapseId) : null;
+                        if (!nextCollapse) {
+                            const nextTaskElement = document.querySelector(`.task-item[data-task-id="${taskId}"]`);
+                            nextCollapse = nextTaskElement ? nextTaskElement.querySelector('.accordion-collapse') : null;
+                        }
                         if (nextCollapse) {
                             targetCollapse = nextCollapse;
                         }


### PR DESCRIPTION
Why
- Linked GitHub tasks sometimes failed to reopen their details after the task list refreshed, leaving the task accordion collapsed and confusing users.
- The refresh can replace DOM nodes so relying solely on querying by task id misses the intended collapse element.

What it does
- Captures the collapse element's id before triggering the refresh and attempts to re-select it by id after the refresh.
- Falls back to the existing selector-based lookup if the id-based lookup does not find a match.
- Ensures the correct accordion panel is re-opened after the task list updates, restoring expected UX for linked GitHub tasks.

Benefits
- Prevents task detail panels from staying closed after refreshes.
- Improves reliability of the expand/restore behavior when DOM nodes are replaced.
- Targets the specific failure scenario without changing broader UI behavior.

Fixes #33