### PR TITLE
Add GitHub linking action for unlinked tasks

### DIFF
--- a/templates/components/task_groups.html
+++ b/templates/components/task_groups.html
@@ -107,6 +107,19 @@
                                     <button type="button" class="btn task-action-btn task-copy-btn" aria-label="Copy task {{ task.name | e }}">
                                         <i class="bi bi-clipboard"></i>
                                     </button>
+                                    {% if github_enabled and not task.has_github_issue %}
+                                        <button type="button"
+                                                class="btn task-action-btn task-github-btn"
+                                                data-task-id="{{ task.id }}"
+                                                data-has-issue="false"
+                                                data-task-has-github="false"
+                                                data-task-github-state=""
+                                                aria-label="Link with GitHub"
+                                                title="Link with GitHub">
+                                            <i class="bi bi-github"></i>
+                                            <span class="visually-hidden">Link with GitHub</span>
+                                        </button>
+                                    {% endif %}
                                     <button type="button" class="btn task-action-btn tag-manager-btn" data-task-id="{{ task.id }}" data-task-name="{{ task.name | e }}" data-task-has-github="{{ 'true' if task.has_github_issue else 'false' }}">
                                         <i class="bi bi-tags"></i>
                                     </button>


### PR DESCRIPTION
## Summary
- show the Link with GitHub action button for tasks without an associated issue when GitHub integration is available
- wire the button into the existing linking flow with accessibility labels so users can create the first GitHub issue from a task

## Testing
- pytest
 
 Closes #67 

------
https://chatgpt.com/codex/tasks/task_b_68e7779ba7008330b7125b9efa6cb69c